### PR TITLE
[Fix CODEASSIST] updated api/v1/auth/app-initalization-details response

### DIFF
--- a/backend/src/zango/api/platform/auth/v1/views.py
+++ b/backend/src/zango/api/platform/auth/v1/views.py
@@ -155,8 +155,10 @@ class AppPanelDetailsView(ZangoGenericPlatformAPIView):
             serializer = PlatformUserSerializerModel(obj)
             success = True
             response = {
-                "app_data": {"user_logged_in": serializer.data},
-                "is_codeassist_enabled": getattr(settings, "CODEASSIST_ENABLED", False),
+                "app_data": {
+                    "user_logged_in": serializer.data,
+                    "is_codeassist_enabled": getattr(settings, "CODEASSIST_ENABLED", False)
+                },
             }
             status = 200
         except Exception as e:


### PR DESCRIPTION
Updated the api response to send `"is_codeassist_enabled": true` in `app_data`
Tested Locally
```
{
    "success": true,
    "response": {
        "app_data": {
            "user_logged_in": {
                // user-data
            },
            "is_codeassist_enabled": true
        }
    }
}
```

Link to the issue: https://github.com/Healthlane-Technologies/zelthy3/issues/189