### PR TITLE
Removed unnecessary if else conditions for get or create ORM method in Celery CrontabSchedule model

### DIFF
--- a/backend/src/zango/apps/tasks/utils.py
+++ b/backend/src/zango/apps/tasks/utils.py
@@ -99,7 +99,4 @@ def get_crontab_obj(crontab={}):
           "month_of_year": "*"
         }
 
-    schedule, created = CrontabSchedule.objects.get_or_create(**crontab)
-    if created:
-        return schedule, True
-    return schedule, False
+    return CrontabSchedule.objects.get_or_create(**crontab)


### PR DESCRIPTION
Did just a simple change of removing unnecessary if else condition for CrontabSchedule model get_or_create ORM model.
Instead of checking the boolean value with created variable we can simply return as it is already in the format we need.