### PR TITLE
fixed-incorrect-template-path-handling

### DIFF
--- a/backend/src/zango/cli/start_project.py
+++ b/backend/src/zango/cli/start_project.py
@@ -98,7 +98,7 @@ def create_project(
     project_template_path = os.path.join(
         os.path.dirname(zango.cli.__file__), "project_template"
     )
-    command = f"{command} --template '{str(project_template_path)}'"
+    command = f'{command} --template "{str(project_template_path)}"'
 
     subprocess.run(command, shell=True, check=True)
     env_keys = {


### PR DESCRIPTION


**🚀Fixes #437 Corrected start-project Command to Handle Template Path Properly**
----------------------------------------------------------------------------

### **🔍 Issue Description**

The zango start-project command was failing due to incorrect template path handling when executing the subprocess.run command. The issue was caused by inconsistent path formatting, particularly when running on **Windows**, where single quotes (') around the template path were causing execution errors.

### **⚠️ Root Cause**

The original implementation:

```python
command = f"{command} --template '{str(project_template_path)}'"
subprocess.run(command, shell=True, check=True)
```

*   **Problem:** On Windows, using **single quotes (')** around paths in shell commands can cause errors.
    
*   **Expected Behavior:** The command should execute correctly regardless of the operating system.
    

### **✅ Solution**

The fix ensures proper **path formatting** by replacing single quotes with double quotes ("), making it compatible with both **Windows and Unix-based systems**:

```python 
command = f'{command} --template "{project_template_path}"'
subprocess.run(command, shell=True, check=True)
```
*   **Why This Works?**
    
    *   Windows expects double quotes for file paths in shell commands.
        
    *   Unix-based systems (Linux/macOS) work with both single and double quotes but handle escaping differently.
        
    *   This change improves **cross-platform compatibility** and ensures the command runs as expected.
        

### **🛠️ Changes Made**

*   **Updated:** start\_project.py to properly format the --template path.
    
*   **Ensured Compatibility:** Works correctly across **Windows, Linux, and macOS**.
    
*   **Tested:** Successfully executed zango start-project "MyProject" without issues.