### PR TITLE
bugfix: Error in creating a project

### DIFF
--- a/backend/src/zango/cli/start_project.py
+++ b/backend/src/zango/cli/start_project.py
@@ -98,7 +98,8 @@ def create_project(
     project_template_path = os.path.join(
         os.path.dirname(zango.cli.__file__), "project_template"
     )
-    command = f"{command} --template '{str(project_template_path)}'"
+    # command = f"{command} --template '{str(project_template_path)}'"
+    command = f'{command} --template "{project_template_path}"'
 
     subprocess.run(command, shell=True, check=True)
     env_keys = {


### PR DESCRIPTION
* Fixed Windows path handling for subprocess.run in startproject command.
* Replaced double quotes with single quotes to prevent misinterpretation in cmd.exe.