### PR TITLE
Update init.sh with POSIX-compliant for solving docker compose up on bash

### DIFF
--- a/deploy/init.sh
+++ b/deploy/init.sh
@@ -28,7 +28,17 @@ if [ "$ENV" = "dev" ]; then
             zango update-apps
         fi
     else
-        zango start-project $PROJECT_NAME --db_name="$POSTGRES_DB" --db_user="$POSTGRES_USER" --db_password="$POSTGRES_PASSWORD" --db_host="$POSTGRES_HOST" --db_port="$POSTGRES_PORT" --platform_username="$PLATFORM_USERNAME" --platform_user_password="$PLATFORM_USER_PASSWORD" --redis_host="$REDIS_HOST" --redis_port="$REDIS_PORT" --platform_domain_url="$PLATFORM_DOMAIN_URL"
+        zango start-project "$PROJECT_NAME" \
+            --db_name="$POSTGRES_DB" \
+            --db_user="$POSTGRES_USER" \
+            --db_password="$POSTGRES_PASSWORD" \
+            --db_host="$POSTGRES_HOST" \
+            --db_port="$POSTGRES_PORT" \
+            --platform_username="$PLATFORM_USERNAME" \
+            --platform_user_password="$PLATFORM_USER_PASSWORD" \
+            --redis_host="$REDIS_HOST" \
+            --redis_port="$REDIS_PORT" \
+            --platform_domain_url="$PLATFORM_DOMAIN_URL"
         cd "$PROJECT_NAME"
     fi
     python manage.py runserver 0.0.0.0:8000
@@ -41,7 +51,17 @@ else
             zango update-apps
         fi
     else
-        zango start-project $PROJECT_NAME --db_name="$POSTGRES_DB" --db_user="$POSTGRES_USER" --db_password="$POSTGRES_PASSWORD" --db_host="$POSTGRES_HOST" --db_port="$POSTGRES_PORT" --platform_username="$PLATFORM_USERNAME" --platform_user_password="$PLATFORM_USER_PASSWORD" --redis_host="$REDIS_HOST" --redis_port="$REDIS_PORT" --platform_domain_url="$PLATFORM_DOMAIN_URL"
+        zango start-project "$PROJECT_NAME" \
+            --db_name="$POSTGRES_DB" \
+            --db_user="$POSTGRES_USER" \
+            --db_password="$POSTGRES_PASSWORD" \
+            --db_host="$POSTGRES_HOST" \
+            --db_port="$POSTGRES_PORT" \
+            --platform_username="$PLATFORM_USERNAME" \
+            --platform_user_password="$PLATFORM_USER_PASSWORD" \
+            --redis_host="$REDIS_HOST" \
+            --redis_port="$REDIS_PORT" \
+            --platform_domain_url="$PLATFORM_DOMAIN_URL"
         cd "$PROJECT_NAME"
     fi
     cp /zango/config/gunicorn.conf.py .


### PR DESCRIPTION
Refactored `deploy/init.sh` with POSIX-compliant to resolve issues when `/bin/sh/` is not linked to Bash.
This fixes the Docker install failure caused by using Bash- specific syntax with a POSIX-shell
- closes #492 
