### PR TITLE
feat(cli): add create-user command to create users via CLI

### DIFF
--- a/backend/src/zango/cli/__init__.py
+++ b/backend/src/zango/cli/__init__.py
@@ -6,6 +6,7 @@ from zango.cli import (
     package_info,
     start_project,
     update_apps,
+    create_user,
 )
 
 
@@ -20,6 +21,7 @@ cli.add_command(package_info.list_packages)
 cli.add_command(install_package.install_package)
 cli.add_command(git_setup.git_setup)
 cli.add_command(update_apps.update_apps)
+cli.add_command(create_user.create_user)
 
 if __name__ == "__main__":
     cli()

--- a/backend/src/zango/cli/create_user.py
+++ b/backend/src/zango/cli/create_user.py
@@ -1,0 +1,43 @@
+import os
+import sys
+import click
+import django
+
+from django.core.exceptions import ValidationError
+
+
+@click.command(name="create-user")
+@click.option("--email", prompt=True, help="Email address for the user")
+@click.option("--password", prompt=True, hide_input=True, confirmation_prompt=True, help="Password for the user")
+def create_user(email, password):
+
+    project_name = os.getenv("PROJECT_NAME")
+    if not project_name:
+        raise click.ClickException("PROJECT_NAME environment variable not set.")
+    
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", f"{project_name}.settings")
+    sys.path.insert(0, os.getcwd())
+
+    django.setup()
+
+    from zango.apps.shared.platformauth.models import PlatformUserModel
+
+    click.echo(f"Creating user with email: {email}")
+
+    try:
+        result = PlatformUserModel.create_user(
+            name="CLI Created User",
+            email=email,
+            password=password,
+            is_superadmin=True,
+            mobile="",
+            require_verification=False,
+        )
+        if result["success"]:
+            click.echo("User created successfully.")
+        else:
+            click.echo(f"Failed to create user: {result['message']}")
+    except ValidationError as e:
+        raise click.ClickException(f"Validation Error: {str(e)}")
+    except Exception as e:
+        raise click.ClickException(f"Error: {str(e)}")

--- a/backend/src/zango/cli/start_project.py
+++ b/backend/src/zango/cli/start_project.py
@@ -12,6 +12,7 @@ import django
 from django.core.management import call_command
 
 import zango
+import zango.cli
 
 
 def test_db_conection(db_name, db_user, db_password, db_host, db_port):

--- a/my_project_AK/manage.py
+++ b/my_project_AK/manage.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python
+"""Django's command-line utility for administrative tasks."""
+
+import os
+import sys
+
+
+def main():
+    """Run administrative tasks."""
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "my_project_AK.settings")
+    try:
+        from django.core.management import execute_from_command_line
+    except ImportError as exc:
+        raise ImportError(
+            "Couldn't import Django. Are you sure it's installed and "
+            "available on your PYTHONPATH environment variable? Did you "
+            "forget to activate a virtual environment?"
+        ) from exc
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == "__main__":
+    main()

--- a/my_project_AK/my_project_AK/__init__.py
+++ b/my_project_AK/my_project_AK/__init__.py
@@ -1,0 +1,4 @@
+from zango.config.celery import app as celery_app
+
+
+__all__ = ["celery_app"]

--- a/my_project_AK/my_project_AK/asgi.py
+++ b/my_project_AK/my_project_AK/asgi.py
@@ -1,0 +1,29 @@
+"""
+ASGI config for testproject project.
+
+It exposes the ASGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/4.2/howto/deployment/asgi/
+"""
+
+import os
+
+from django.core.asgi import get_asgi_application
+
+from zango.core.monitoring import setup_telemetry
+
+
+# The telemetry instrumentation library setup needs to run prior to django's setup.
+setup_telemetry(add_django_instrumentation=True)
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "my_project_AK.settings")
+
+application = get_asgi_application()
+
+# Our custom loguru logging to should be setup after django has been setup as Django
+# will try to override with its own logging setup.
+from zango.core.monitoring import setup_logging  # noqa: E402
+
+
+setup_logging()

--- a/my_project_AK/my_project_AK/settings.py
+++ b/my_project_AK/my_project_AK/settings.py
@@ -1,0 +1,46 @@
+from pathlib import Path
+
+from zango.config.settings.base import *  # noqa: F403
+
+
+BASE_DIR = Path(__file__).resolve().parent.parent
+
+
+class AttrDict(dict):
+    """
+    A dictionary subclass for managing global settings with attribute-style access.
+
+    This class allows getting and setting items in the global namespace
+    using both attribute and item notation.
+    """
+
+    def __getattr__(self, item):
+        return globals()[item]
+
+    def __setattr__(self, item, value):
+        globals()[item] = value
+
+    def __setitem__(self, key, value):
+        globals()[key] = value
+
+
+# Call setup_settings to initialize the settings
+settings_result = setup_settings(AttrDict(vars()), BASE_DIR)
+
+# Setting Overrides
+# Any settings that need to be overridden or added should be done below this line
+# to ensure they take effect after the initial setup
+
+SECRET_KEY = "django-insecure-tw4_dzxqhv70rf-vhikj#uyh9ynx4@)+kuy0%eh1biv^!ao0g0"  # Shift this to .env
+
+
+# To change the media storage to S3 you can use the BACKEND class provided by the default storage
+# To change the static storage to S3 you can use the BACKEND class provided by the staticfiles storage
+# STORAGES = {
+#     "default": {"BACKEND": "zango.core.storage_utils.S3MediaStorage"},
+#     "staticfiles": {"BACKEND": "zango.core.storage_utils.S3StaticStorage"},
+# }
+
+
+# INTERNAL_IPS can contain a list of IP addresses or CIDR blocks that are considered internal.
+# Both individual IP addresses and CIDR notation (e.g., '192.168.1.1' or '192.168.1.0/24') can be provided.

--- a/my_project_AK/my_project_AK/urls.py
+++ b/my_project_AK/my_project_AK/urls.py
@@ -1,0 +1,24 @@
+"""
+URL configuration for testproject project.
+
+The `urlpatterns` list routes URLs to views. For more information please see:
+    https://docs.djangoproject.com/en/4.2/topics/http/urls/
+Examples:
+Function views
+    1. Add an import:  from my_app import views
+    2. Add a URL to urlpatterns:  path('', views.home, name='home')
+Class-based views
+    1. Add an import:  from other_app.views import Home
+    2. Add a URL to urlpatterns:  path('', Home.as_view(), name='home')
+Including another URLconf
+    1. Import the include() function: from django.urls import include, path
+    2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
+"""
+
+from django.contrib import admin
+from django.urls import path
+
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+]

--- a/my_project_AK/my_project_AK/urls_public.py
+++ b/my_project_AK/my_project_AK/urls_public.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+from django.urls import include, path
+
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("^", include("zango.config.urls_public")),
+]

--- a/my_project_AK/my_project_AK/urls_tenants.py
+++ b/my_project_AK/my_project_AK/urls_tenants.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+from django.urls import include, path
+
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("", include("zango.config.urls_tenants")),
+]

--- a/my_project_AK/my_project_AK/wsgi.py
+++ b/my_project_AK/my_project_AK/wsgi.py
@@ -1,0 +1,31 @@
+"""
+WSGI config for testproject project.
+
+It exposes the WSGI callable as a module-level variable named ``application``.
+
+For more information on this file, see
+https://docs.djangoproject.com/en/4.2/howto/deployment/wsgi/
+"""
+
+import os
+
+
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "my_project_AK.settings")
+
+
+from django.core.wsgi import get_wsgi_application  # noqa: E402
+
+from zango.core.monitoring import setup_telemetry  # noqa: E402
+
+
+# The telemetry instrumentation library setup needs to run prior to django's setup.
+setup_telemetry(add_django_instrumentation=True)
+
+application = get_wsgi_application()
+
+# Our custom loguru logging to should be setup after django has been setup as Django
+# will try to override with its own logging setup.
+from zango.core.monitoring import setup_logging  # noqa: E402
+
+
+setup_logging()


### PR DESCRIPTION
This PR introduces a `create-user` CLI command to Zango's CLI tools.

- Prompts for email and password
- Validates password match
- Creates a Django superuser interactively

This improves developer experience during project setup and removes the need for raw shell commands or admin panel access.