### PR TITLE
Add support for model permissions

### DIFF
--- a/backend/src/zango/apps/permissions/mixin.py
+++ b/backend/src/zango/apps/permissions/mixin.py
@@ -85,18 +85,24 @@ class PermissionMixin:
                 statement__permissions__contains=[{"type": perm_type, "name": view}]
             )
         elif perm_type == "model":
+            # Support both explicit 'model' type entries and permissive entries
+            # that might only include the name. This keeps backward compatibility
+            # with older policies that used only the name for datamodels.
+            from django.db.models import Q as _Q
+
             qs = valid_policies_qs.filter(
-                statement__permissions__contains=[{"type": perm_type, "name": model}]
+                _Q(statement__permissions__contains=[{"type": perm_type, "name": model}])
+                | _Q(statement__permissions__contains=[{"name": model}])
             )
         else:
             qs = PolicyModel.objects.none()
         return qs
 
-    def has_perm(self, request, perm_type, view_name=None):
+    def has_perm(self, request, perm_type, view_name=None, model=None):
         """
         checks if the role or user has the permission
         """
-        policies = self.get_policies(perm_type, view_name)
+        policies = self.get_policies(perm_type, view_name, model)
         if not policies.exists():
             return False
         if perm_type == "userAccess":
@@ -111,6 +117,17 @@ class PermissionMixin:
                 for permission in permissions:
                     if self.has_view_access(permission, view_name):
                         return True
+        elif perm_type == "model":
+            # Check if any policy grants access to the requested model
+            for policy in policies:
+                permissions = policy.statement.get("permissions")
+                for permission in permissions:
+                    # accept explicit model type or older entries that only include name
+                    if permission.get("name") == model and (
+                        permission.get("type") in ("model", "dataModel", "datamodel")
+                        or permission.get("type") is None
+                    ):
+                        return True
         return False
 
     def get_model_perms(self, model):
@@ -124,7 +141,10 @@ class PermissionMixin:
             Q(is_active=True, expiry__gte=timezone.now())
             | Q(is_active=True, expiry__isnull=True)
         )
+        from django.db.models import Q as _Q
+
         qs = valid_policies_qs.filter(
-            statement__permissions__contains=[{"name": model}]
+            _Q(statement__permissions__contains=[{"type": "model", "name": model}])
+            | _Q(statement__permissions__contains=[{"name": model}])
         )
         return qs

--- a/backend/src/zango/apps/permissions/models.py
+++ b/backend/src/zango/apps/permissions/models.py
@@ -14,6 +14,8 @@ class PermissionsModel(FullAuditMixin):
         choices=(
             ("view", "View"),
             ("datamodel", "DataModel"),
+            ("dataModel", "DataModel"),
+            ("model", "Model"),
             ("user_access", "User Access"),
             ("custom", "Custom"),
         ),


### PR DESCRIPTION
Enhance the permission framework by introducing support for model permissions. This update allows for both explicit 'model' type entries and permissive entries that only include the model name, ensuring backward compatibility with existing policies. The `has_perm` method now checks for model permissions, and the `get_model_perms` method has been updated accordingly.

Fixes #185