### PR TITLE
fix package tab 500 when multiple domains mapped to an app

### DIFF
--- a/backend/src/zango/apps/shared/tenancy/models.py
+++ b/backend/src/zango/apps/shared/tenancy/models.py
@@ -127,6 +127,9 @@ class TenantModel(TenantMixin, FullAuditMixin):
     def __str__(self):
         return self.name
 
+    def get_primary_domain(self):
+        return self.domains.filter(is_primary=True).first()
+
     def suspend(self):
         self.status = "suspended"
         self.suspended_on = timezone.now()


### PR DESCRIPTION
## Summary
- Overrides `get_primary_domain()` on `TenantModel` to use `.filter(is_primary=True).first()` instead of inheriting django-tenants' `.get()` which raises `MultipleObjectsReturned` when multiple domains are marked primary.
- Fixes 500 error on the package detail page when multiple domains are mapped to a single application.

Fixes #288

## Test plan
- [ ] Map multiple domains to a single application
- [ ] Navigate to the package tab in App Panel
- [ ] Confirm package list loads without 500 error
- [ ] Confirm package configuration URLs resolve correctly