### PR TITLE
feat(ai): persist tool call/result rounds in session memory

### DIFF
--- a/backend/src/zango/ai/agent_client.py
+++ b/backend/src/zango/ai/agent_client.py
@@ -356,9 +356,6 @@ class AgentClient:
                     msg.files = None
                     break
 
-        # Capture the new-turn slice (excludes history) for memory persistence
-        new_user_messages_for_memory = messages[len(history_messages) :]
-
         for round_number in range(1, max_tool_rounds + 2):
             response = provider_client.complete(
                 messages=messages,
@@ -442,10 +439,11 @@ class AgentClient:
 
         # ── Memory: persist this exchange ─────────────────────────────────────
         if session_id and self._agent.memory_enabled:
+            new_messages_for_memory = messages[len(history_messages) :]
             self._save_session_messages(
                 session_id=session_id,
                 user_ref=user_ref,
-                input_messages=new_user_messages_for_memory,
+                new_messages=new_messages_for_memory,
                 response=response,
             )
             response.session_id = session_id
@@ -454,11 +452,29 @@ class AgentClient:
 
     # ─────────────────────────────── Memory helpers ───────────────────────────
 
+    def _get_excluded_tool_names(self) -> set:
+        """
+        Return the set of tool names whose memory_policy is "exclude".
+        These tools' call/result messages are dropped from loaded history.
+        """
+        from zango.apps.ai.models.tool import AppLLMTool
+
+        if not self._agent.tools:
+            return set()
+
+        return set(
+            AppLLMTool.objects.filter(
+                name__in=self._agent.tools,
+                memory_policy="exclude",
+            ).values_list("name", flat=True)
+        )
+
     def _load_session_messages(self, session_id: str) -> list:
         """
         Load prior messages for this session from the DB.
         Returns LLMMessage list ordered oldest-first, capped to
-        memory_max_messages pairs (each pair = 1 user + 1 assistant).
+        memory_max_messages rows. Tool call/result message pairs whose
+        tool has memory_policy="exclude" are dropped from the loaded history.
         Fail-open: returns [] on any error so the LLM call is never blocked.
         """
         from zango.apps.ai.models.memory import AppLLMMemorySession
@@ -473,20 +489,102 @@ class AgentClient:
             if not session:
                 return []
 
-            max_rows = (
-                self._agent.memory_max_messages * 2
-            )  # pairs → individual messages
+            max_rows = self._agent.memory_max_messages * 2
             db_messages = list(session.messages.order_by("-sequence")[:max_rows])
             db_messages.reverse()  # oldest-first
 
+            excluded_tools = self._get_excluded_tool_names()
+
+            # Identify sequences belonging to excluded tool rounds.
+            # Strategy: walk messages in order; when an assistant message contains
+            # a tool_use block for an excluded tool, mark it excluded and mark the
+            # immediately following tool-result message (role="tool" for OpenAI or
+            # role="user" with tool_result blocks for Anthropic) as excluded too.
+            excluded_sequences = set()
+            if excluded_tools:
+                prev_assistant_excluded = False
+                for m in db_messages:
+                    if m.role == "assistant" and isinstance(m.content, list):
+                        tool_use_names = {
+                            b.get("name")
+                            for b in m.content
+                            if isinstance(b, dict) and b.get("type") == "tool_use"
+                        }
+                        if tool_use_names & excluded_tools:
+                            excluded_sequences.add(m.sequence)
+                            prev_assistant_excluded = True
+                        else:
+                            prev_assistant_excluded = False
+
+                    elif m.role == "tool":
+                        # OpenAI-style tool result follows the preceding assistant
+                        if prev_assistant_excluded:
+                            excluded_sequences.add(m.sequence)
+                        prev_assistant_excluded = False
+
+                    elif m.role == "user" and isinstance(m.content, list):
+                        if any(
+                            isinstance(b, dict) and b.get("type") == "tool_result"
+                            for b in m.content
+                        ):
+                            # Anthropic-style tool result follows the preceding assistant
+                            if prev_assistant_excluded:
+                                excluded_sequences.add(m.sequence)
+                        prev_assistant_excluded = False
+
+                    else:
+                        prev_assistant_excluded = False
+
+            is_openai = self._is_openai_style_provider()
+
             result = []
             for m in db_messages:
-                result.append(
-                    LLMMessage(
-                        role=m.role,
-                        content=m.content,
+                if m.sequence in excluded_sequences:
+                    continue
+
+                kwargs = {"role": m.role, "content": m.content}
+
+                if m.role == "tool" and isinstance(m.content, dict):
+                    # OpenAI-style tool result stored as {content, tool_call_id}
+                    kwargs["content"] = m.content.get("content", m.content)
+                    kwargs["tool_call_id"] = m.content.get("tool_call_id")
+
+                elif (
+                    is_openai
+                    and m.role == "assistant"
+                    and isinstance(m.content, list)
+                    and any(
+                        isinstance(b, dict) and b.get("type") == "tool_use"
+                        for b in m.content
                     )
-                )
+                ):
+                    # Assistant tool-use round was stored in Anthropic-style content blocks.
+                    # Convert back to OpenAI tool_calls format so the SDK doesn't reject it.
+                    tool_calls = [
+                        {
+                            "id": b.get("id"),
+                            "type": "function",
+                            "function": {
+                                "name": b.get("name"),
+                                "arguments": (
+                                    b.get("input")
+                                    if isinstance(b.get("input"), str)
+                                    else json.dumps(b.get("input") or {})
+                                ),
+                            },
+                        }
+                        for b in m.content
+                        if isinstance(b, dict) and b.get("type") == "tool_use"
+                    ]
+                    text_blocks = [
+                        b.get("text", "")
+                        for b in m.content
+                        if isinstance(b, dict) and b.get("type") == "text"
+                    ]
+                    kwargs["content"] = " ".join(text_blocks) if text_blocks else None
+                    kwargs["tool_calls"] = tool_calls
+
+                result.append(LLMMessage(**kwargs))
             return result
 
         except Exception as e:
@@ -500,14 +598,15 @@ class AgentClient:
         self,
         session_id: str,
         user_ref: str,
-        input_messages: list,
+        new_messages: list,
         response,
     ) -> None:
         """
-        Persist the user input(s) and final assistant response to the DB.
-        Stores only role=user messages and the final role=assistant message.
-        File content blocks are replaced with [file: attachment] placeholders.
-        Fail-open: logs error but never re-raises so the caller still gets the response.
+        Persist all messages from the current turn to the DB, including
+        intermediate tool call/result rounds. File content blocks are replaced
+        with lightweight placeholders. The final assistant text response is
+        always persisted last.
+        Fail-open: logs error but never re-raises so the caller gets the response.
         """
         from django.db import transaction
         from django.db.models import Max
@@ -521,7 +620,6 @@ class AgentClient:
                     session_id=session_id,
                     defaults={"user_ref": user_ref},
                 )
-                # Trigger auto_now update on last_active_at
                 session.save(update_fields=["last_active_at"])
 
                 agg = session.messages.aggregate(max_seq=Max("sequence"))
@@ -529,8 +627,40 @@ class AgentClient:
 
                 to_create = []
 
-                for msg in input_messages:
-                    if msg.role == "user":
+                for msg in new_messages:
+                    is_anthropic_tool_result = (
+                        msg.role == "user"
+                        and isinstance(msg.content, list)
+                        and any(
+                            isinstance(b, dict) and b.get("type") == "tool_result"
+                            for b in msg.content
+                        )
+                    )
+                    is_assistant_tool_use = msg.role == "assistant" and (
+                        msg.tool_calls
+                        or (
+                            isinstance(msg.content, list)
+                            and any(
+                                isinstance(b, dict) and b.get("type") == "tool_use"
+                                for b in msg.content
+                            )
+                        )
+                    )
+
+                    if is_anthropic_tool_result:
+                        # Anthropic-style tool result block (role=user with tool_result)
+                        to_create.append(
+                            AppLLMMemoryMessage(
+                                session=session,
+                                role="user",
+                                content=msg.content,
+                                invocation_id=response.invocation_id,
+                                sequence=next_seq,
+                            )
+                        )
+                        next_seq += 1
+
+                    elif msg.role == "user":
                         content = self._sanitize_content_for_memory(msg.content)
                         to_create.append(
                             AppLLMMemoryMessage(
@@ -543,7 +673,53 @@ class AgentClient:
                         )
                         next_seq += 1
 
-                # Save the final assistant response
+                    elif is_assistant_tool_use:
+                        # Intermediate assistant message with tool calls — persist verbatim.
+                        # OpenAI-style: content may be None when tool calls live in msg.tool_calls.
+                        # Reconstruct content list so the JSONField is never null.
+                        if msg.content is not None:
+                            content = self._sanitize_content_for_memory(msg.content)
+                        elif msg.tool_calls:
+                            content = [
+                                {
+                                    "type": "tool_use",
+                                    "id": tc.get("id"),
+                                    "name": tc.get("function", {}).get("name"),
+                                    "input": tc.get("function", {}).get("arguments"),
+                                }
+                                for tc in msg.tool_calls
+                            ]
+                        else:
+                            content = []
+                        to_create.append(
+                            AppLLMMemoryMessage(
+                                session=session,
+                                role="assistant",
+                                content=content,
+                                invocation_id=response.invocation_id,
+                                sequence=next_seq,
+                            )
+                        )
+                        next_seq += 1
+
+                    elif msg.role == "tool":
+                        # OpenAI-style tool result — store content + tool_call_id together
+                        stored_content = {
+                            "content": msg.content,
+                            "tool_call_id": msg.tool_call_id,
+                        }
+                        to_create.append(
+                            AppLLMMemoryMessage(
+                                session=session,
+                                role="tool",
+                                content=stored_content,
+                                invocation_id=response.invocation_id,
+                                sequence=next_seq,
+                            )
+                        )
+                        next_seq += 1
+
+                # Final assistant text response
                 if response.content:
                     to_create.append(
                         AppLLMMemoryMessage(

--- a/backend/src/zango/ai/tools/decorator.py
+++ b/backend/src/zango/ai/tools/decorator.py
@@ -62,6 +62,7 @@ class ToolMeta:
     python_path: str
     return_type: str | None
     schema_hash: str
+    memory_policy: str = "include"  # "include" | "exclude"
 
 
 class _ToolDecorator:
@@ -86,6 +87,7 @@ def tool(
     safety: ToolSafety = ToolSafety.READ_ONLY,
     timeout_seconds: int = 30,
     rate_limit: int | None = None,
+    memory_policy: str = "include",
 ) -> Callable:
     """
     Decorator that registers a function as an LLM tool.
@@ -97,6 +99,8 @@ def tool(
         safety: READ_ONLY, WRITE, or EXTERNAL.
         timeout_seconds: Max execution time before kill.
         rate_limit: Max calls per minute. None = unlimited.
+        memory_policy: "include" (default) — replay verbatim in session history.
+            "exclude" — drop from loaded history (use for side-effect tools).
     """
 
     def decorator(func: Callable) -> _ToolDecorator:
@@ -126,6 +130,7 @@ def tool(
             python_path=python_path,
             return_type=return_type,
             schema_hash=schema_hash,
+            memory_policy=memory_policy,
         )
 
         func._tool_meta = meta

--- a/backend/src/zango/api/platform/ai/v1/serializers.py
+++ b/backend/src/zango/api/platform/ai/v1/serializers.py
@@ -866,6 +866,7 @@ class AppLLMToolListSerializer(serializers.ModelSerializer):
             "schema_hash",
             "python_path",
             "params_count",
+            "memory_policy",
         ]
 
     def get_params_count(self, obj):
@@ -891,6 +892,7 @@ class AppLLMToolDetailSerializer(serializers.ModelSerializer):
             "return_type",
             "is_active",
             "schema_hash",
+            "memory_policy",
             "total_calls",
             "total_errors",
             "total_timeouts",

--- a/backend/src/zango/apps/ai/migrations/0002_appllmtool_memory_policy.py
+++ b/backend/src/zango/apps/ai/migrations/0002_appllmtool_memory_policy.py
@@ -1,0 +1,30 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("ai", "0001_initial"),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name="appllmtool",
+            name="memory_policy",
+            field=models.CharField(
+                choices=[
+                    ("include", "Include — replay verbatim in session history"),
+                    (
+                        "exclude",
+                        "Exclude — drop from loaded history (side-effect tools)",
+                    ),
+                ],
+                default="include",
+                help_text=(
+                    "include: replay tool call/result verbatim in session history (default). "
+                    "exclude: drop from loaded history — use for side-effect tools (send_email, etc.)."
+                ),
+                max_length=10,
+            ),
+        ),
+    ]

--- a/backend/src/zango/apps/ai/models/memory.py
+++ b/backend/src/zango/apps/ai/models/memory.py
@@ -51,8 +51,10 @@ class AppLLMMemorySession(FullAuditMixin):
 class AppLLMMemoryMessage(FullAuditMixin):
     """
     A single stored message within a memory session.
-    Only user input and final assistant responses are stored — not
-    intermediate tool-call rounds (they are ephemeral scaffolding).
+    Stores user input, assistant responses, and tool call/result rounds
+    so they are replayed verbatim on subsequent agent.run() calls.
+    role is one of: "user", "assistant", "tool" (OpenAI-style tool result),
+    or "assistant_tool_use" (Anthropic-style tool-use round).
     """
 
     session = models.ForeignKey(
@@ -62,7 +64,7 @@ class AppLLMMemoryMessage(FullAuditMixin):
     )
     role = models.CharField(
         max_length=20,
-        help_text="'user' or 'assistant'",
+        help_text="'user', 'assistant', or 'tool'",
     )
     content = models.JSONField(
         help_text="Message content — str or list of content blocks",

--- a/backend/src/zango/apps/ai/models/tool.py
+++ b/backend/src/zango/apps/ai/models/tool.py
@@ -21,6 +21,11 @@ class AppLLMTool(FullAuditMixin):
         ("external", "External"),
     ]
 
+    MEMORY_POLICY_CHOICES = [
+        ("include", "Include — replay verbatim in session history"),
+        ("exclude", "Exclude — drop from loaded history (side-effect tools)"),
+    ]
+
     name = models.CharField(max_length=100, unique=True)
     description = models.TextField()
     section = models.CharField(max_length=50, default="general")
@@ -36,6 +41,15 @@ class AppLLMTool(FullAuditMixin):
     return_type = models.CharField(max_length=100, null=True, blank=True)
     is_active = models.BooleanField(default=True)
     schema_hash = models.CharField(max_length=64)
+    memory_policy = models.CharField(
+        max_length=10,
+        choices=MEMORY_POLICY_CHOICES,
+        default="include",
+        help_text=(
+            "include: replay tool call/result verbatim in session history (default). "
+            "exclude: drop from loaded history — use for side-effect tools (send_email, etc.)."
+        ),
+    )
 
     # Usage stats
     total_calls = models.IntegerField(default=0)

--- a/backend/src/zango/apps/dynamic_models/workspace/base.py
+++ b/backend/src/zango/apps/dynamic_models/workspace/base.py
@@ -386,6 +386,7 @@ class Workspace:
                         or tool_record.section != meta.section
                         or tool_record.safety != meta.safety.value
                         or tool_record.python_path != python_path
+                        or tool_record.memory_policy != meta.memory_policy
                     )
                     if needs_update:
                         tool_record.description = meta.description
@@ -397,6 +398,7 @@ class Workspace:
                         tool_record.python_path = python_path
                         tool_record.return_type = meta.return_type
                         tool_record.schema_hash = meta.schema_hash
+                        tool_record.memory_policy = meta.memory_policy
                         tool_record.is_active = True
                         tool_record.save()
                         stats["updated"] += 1
@@ -413,6 +415,7 @@ class Workspace:
                         python_path=python_path,
                         return_type=meta.return_type,
                         schema_hash=meta.schema_hash,
+                        memory_policy=meta.memory_policy,
                         is_active=True,
                     )
                     stats["created"] += 1

--- a/frontend/src/pages/appAi/components/InvocationLogs.jsx
+++ b/frontend/src/pages/appAi/components/InvocationLogs.jsx
@@ -38,8 +38,103 @@ function JsonBlock({ data, maxHeight = '200px' }) {
 	);
 }
 
+/* ─── Render a single memory message row ─── */
+function MemoryMessageRow({ m }) {
+	const content = m.content;
+
+	// Anthropic assistant tool-use round: list of tool_use blocks
+	const isAssistantToolUse = m.role === 'assistant' && Array.isArray(content) &&
+		content.some(b => b?.type === 'tool_use');
+
+	// Anthropic tool result: role=user with tool_result blocks
+	const isToolResult = m.role === 'user' && Array.isArray(content) &&
+		content.length > 0 && content.every(b => b?.type === 'tool_result');
+
+	// OpenAI tool result: role=tool with {content, tool_call_id} stored as dict
+	const isOpenAIToolResult = m.role === 'tool';
+
+	if (isAssistantToolUse) {
+		const toolUseBlocks = content.filter(b => b?.type === 'tool_use');
+		const textBlocks = content.filter(b => b?.type === 'text' && b.text);
+		return (
+			<div className="flex items-start gap-[8px] px-[12px] py-[8px] bg-white">
+				<span className="mt-[1px] shrink-0 rounded-full px-[6px] py-[1px] font-mono text-[10px] font-bold bg-[#F5F3FF] text-[#7C3AED]">T</span>
+				<div className="flex flex-col gap-[4px] flex-1 min-w-0">
+					{textBlocks.length > 0 && (
+						<pre className="whitespace-pre-wrap break-words font-lato text-[12px] leading-[18px] text-[#6B7280]">{textBlocks.map(b => b.text).join(' ')}</pre>
+					)}
+					{toolUseBlocks.map((b, i) => (
+						<div key={i} className="inline-flex items-center gap-[6px] rounded-[4px] bg-[#F5F3FF] border border-[#DDD6FE] px-[8px] py-[3px]">
+							<span className="text-[10px]">🔧</span>
+							<span className="font-mono text-[11px] font-semibold text-[#7C3AED]">{b.name}</span>
+							<span className="font-lato text-[10px] text-[#9CA3AF]">
+								{b.input && Object.keys(b.input).length > 0
+									? Object.entries(b.input).map(([k, v]) => `${k}=${JSON.stringify(v)}`).join(', ')
+									: 'no args'}
+							</span>
+						</div>
+					))}
+				</div>
+			</div>
+		);
+	}
+
+	if (isToolResult) {
+		return (
+			<div className="flex items-start gap-[8px] px-[12px] py-[8px] bg-white">
+				<span className="mt-[1px] shrink-0 rounded-full px-[6px] py-[1px] font-mono text-[10px] font-bold bg-[#F5F3FF] text-[#7C3AED]">T</span>
+				<div className="flex flex-col gap-[4px] flex-1 min-w-0">
+					{content.map((b, i) => {
+						let resultText = '';
+						try {
+							const raw = typeof b.content === 'string' ? JSON.parse(b.content) : b.content;
+							resultText = typeof raw === 'object' ? JSON.stringify(raw, null, 2) : String(raw);
+						} catch { resultText = String(b.content || ''); }
+						return (
+							<div key={i} className="rounded-[4px] bg-[#F0FDF4] border border-[#BBF7D0] px-[8px] py-[4px]">
+								<span className="block font-lato text-[10px] font-bold text-[#059669] mb-[2px]">↩ tool result</span>
+								<pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[17px] text-[#374151] max-h-[80px] overflow-auto">{resultText}</pre>
+							</div>
+						);
+					})}
+				</div>
+			</div>
+		);
+	}
+
+	if (isOpenAIToolResult) {
+		const stored = typeof content === 'object' && content !== null && !Array.isArray(content) ? content : {};
+		const resultText = stored.content ?? (typeof content === 'string' ? content : JSON.stringify(content));
+		return (
+			<div className="flex items-start gap-[8px] px-[12px] py-[8px] bg-white">
+				<span className="mt-[1px] shrink-0 rounded-full px-[6px] py-[1px] font-mono text-[10px] font-bold bg-[#F5F3FF] text-[#7C3AED]">T</span>
+				<div className="rounded-[4px] bg-[#F0FDF4] border border-[#BBF7D0] px-[8px] py-[4px] flex-1 min-w-0">
+					<span className="block font-lato text-[10px] font-bold text-[#059669] mb-[2px]">↩ tool result</span>
+					<pre className="whitespace-pre-wrap break-words font-mono text-[11px] leading-[17px] text-[#374151] max-h-[80px] overflow-auto">{resultText}</pre>
+				</div>
+			</div>
+		);
+	}
+
+	// Regular user or assistant text message
+	const text = Array.isArray(content)
+		? content.filter(b => b?.type === 'text').map(b => b.text).join(' ') || '(empty)'
+		: (content || '(empty)');
+
+	return (
+		<div className="flex items-start gap-[8px] px-[12px] py-[8px] bg-white">
+			<span className={`mt-[1px] shrink-0 rounded-full px-[6px] py-[1px] font-mono text-[10px] font-bold ${
+				m.role === 'user' ? 'bg-[#EFF6FF] text-[#2563EB]' : 'bg-[#F0FDF4] text-[#16A34A]'
+			}`}>
+				{m.role === 'user' ? 'U' : 'A'}
+			</span>
+			<pre className="whitespace-pre-wrap break-words font-lato text-[12px] leading-[18px] text-[#6B7280]">{text}</pre>
+		</div>
+	);
+}
+
 /* ─── Collapsible panel showing memory context messages injected before the current turn ─── */
-function MemoryHistoryPanel({ messages, renderContent }) {
+function MemoryHistoryPanel({ messages }) {
 	const [expanded, setExpanded] = useState(false);
 	const exchangeCount = Math.ceil(messages.length / 2);
 	return (
@@ -61,20 +156,7 @@ function MemoryHistoryPanel({ messages, renderContent }) {
 			</button>
 			{expanded && (
 				<div className="divide-y divide-[#F3F4F6]">
-					{messages.map((m, i) => (
-						<div key={i} className="flex items-start gap-[8px] px-[12px] py-[8px] bg-white">
-							<span className={`mt-[1px] shrink-0 rounded-full px-[6px] py-[1px] font-mono text-[10px] font-bold ${
-								m.role === 'user' ? 'bg-[#EFF6FF] text-[#2563EB]' :
-								m.role === 'assistant' ? 'bg-[#F0FDF4] text-[#16A34A]' :
-								'bg-[#F5F3FF] text-[#7C3AED]'
-							}`}>
-								{m.role === 'user' ? 'U' : m.role === 'assistant' ? 'A' : 'T'}
-							</span>
-							<pre className="whitespace-pre-wrap break-words font-lato text-[12px] leading-[18px] text-[#6B7280]">
-								{renderContent(m.content)}
-							</pre>
-						</div>
-					))}
+					{messages.map((m, i) => <MemoryMessageRow key={i} m={m} />)}
 				</div>
 			)}
 		</div>
@@ -198,19 +280,6 @@ function InvocationDetail({ invocation }) {
 				const hasFileBlocks = currentUserMsg && Array.isArray(currentUserMsg.content) &&
 					currentUserMsg.content.some(b => b.type === 'image_url' || b.type === 'document');
 
-				// Helper to render message text content
-				const renderContent = (content) => {
-					if (Array.isArray(content)) {
-						// tool_result blocks are internal Anthropic protocol — show a neutral label
-						if (content.every(b => b.type === 'tool_result')) {
-							return '(tool result)';
-						}
-						const text = content.filter(b => b.type === 'text').map(b => b.text).join(' ');
-						return text || '(file attachment)';
-					}
-					return content || '(empty)';
-				};
-
 				return (
 					<div className="flex flex-col gap-[12px]">
 
@@ -252,7 +321,7 @@ function InvocationDetail({ invocation }) {
 
 						{/* Memory history context — collapsible, shows prior exchanges loaded from memory */}
 						{hasMemoryHistory && (
-							<MemoryHistoryPanel messages={memoryHistoryMessages} renderContent={renderContent} />
+							<MemoryHistoryPanel messages={memoryHistoryMessages} />
 						)}
 
 						{/* Conversation timeline — current turn only */}

--- a/frontend/src/pages/appAi/components/InvocationLogs.jsx
+++ b/frontend/src/pages/appAi/components/InvocationLogs.jsx
@@ -126,11 +126,25 @@ function InvocationDetail({ invocation }) {
 						: (invocation.request_messages || []);
 				} catch (e) {}
 
-				// Build tool result lookup: tool_call_id -> content
+				// Build tool result lookup for the current turn only (messages after currentUserMsgIdx).
 				// OpenAI format: role="tool" messages with tool_call_id
 				// Anthropic format: role="user" messages with content blocks of type="tool_result" and tool_use_id
+				// We compute currentUserMsgIdx first via a pre-pass so the lookup is scoped correctly.
+				const isToolResultMsg = (m) =>
+					m.role === 'user' &&
+					Array.isArray(m.content) &&
+					m.content.length > 0 &&
+					m.content.every(b => b.type === 'tool_result');
+
+				const userMsgIndices = messages.reduce(
+					(acc, m, i) => (m.role === 'user' && !isToolResultMsg(m)) ? [...acc, i] : acc,
+					[]
+				);
+				const currentUserMsgIdx = userMsgIndices[userMsgIndices.length - 1] ?? -1;
+
 				const toolResults = {};
-				messages.forEach(m => {
+				messages.forEach((m, idx) => {
+					if (idx <= currentUserMsgIdx) return; // skip memory history
 					if (m.role === 'tool' && m.tool_call_id) {
 						toolResults[m.tool_call_id] = m.content;
 					} else if (m.role === 'user' && Array.isArray(m.content)) {
@@ -145,11 +159,15 @@ function InvocationDetail({ invocation }) {
 					}
 				});
 
-				// Collect tool calls made by LLM (from assistant messages in history + current response)
+				// Collect tool calls made by the LLM *in the current turn only* —
+				// i.e. assistant messages that appear AFTER the current user message index.
+				// Memory-injected assistant messages (before currentUserMsgIdx) are excluded
+				// to avoid showing replayed history tool calls as live calls.
 				// OpenAI format: assistant message has tool_calls array
 				// Anthropic format: assistant message has content array with blocks of type="tool_use"
 				const historyToolCalls = [];
-				messages.forEach(m => {
+				messages.forEach((m, idx) => {
+					if (idx <= currentUserMsgIdx) return; // skip memory history
 					if (m.role === 'assistant') {
 						if (m.tool_calls) {
 							m.tool_calls.forEach(tc => historyToolCalls.push(tc));
@@ -172,17 +190,6 @@ function InvocationDetail({ invocation }) {
 				// Anthropic tool-result messages also use role="user" with content blocks of
 				// type "tool_result" — these are NOT the user's actual input and must be skipped
 				// when finding the real current user message.
-				const isToolResultMsg = (m) =>
-					m.role === 'user' &&
-					Array.isArray(m.content) &&
-					m.content.length > 0 &&
-					m.content.every(b => b.type === 'tool_result');
-
-				const userMsgIndices = messages.reduce(
-					(acc, m, i) => (m.role === 'user' && !isToolResultMsg(m)) ? [...acc, i] : acc,
-					[]
-				);
-				const currentUserMsgIdx = userMsgIndices[userMsgIndices.length - 1] ?? -1;
 				const currentUserMsg = currentUserMsgIdx >= 0 ? messages[currentUserMsgIdx] : null;
 				// History = all messages before the current user message (memory context)
 				const memoryHistoryMessages = currentUserMsgIdx > 0 ? messages.slice(0, currentUserMsgIdx) : [];

--- a/frontend/src/pages/appAi/components/Tools.jsx
+++ b/frontend/src/pages/appAi/components/Tools.jsx
@@ -12,6 +12,23 @@ function notify(type, title, description) {
 	);
 }
 
+function MemoryPolicyBadge({ policy }) {
+	if (policy === 'exclude') {
+		return (
+			<span className="inline-flex items-center gap-[4px] rounded-[4px] bg-[#FEF2F2] px-[8px] py-[2px] font-lato text-[11px] font-bold text-[#DC2626]">
+				<svg width="9" height="9" viewBox="0 0 10 10" fill="none"><path d="M2 2l6 6M8 2l-6 6" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round"/></svg>
+				EXCLUDE
+			</span>
+		);
+	}
+	return (
+		<span className="inline-flex items-center gap-[4px] rounded-[4px] bg-[#ECFDF5] px-[8px] py-[2px] font-lato text-[11px] font-bold text-[#059669]">
+			<svg width="9" height="9" viewBox="0 0 10 10" fill="none"><path d="M1.5 5l3 3 4-4" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round"/></svg>
+			INCLUDE
+		</span>
+	);
+}
+
 function SafetyBadge({ safety }) {
 	const styles = {
 		read_only: 'bg-[#ECFDF5] text-[#059669]',
@@ -89,7 +106,11 @@ function ToolDetail({ tool, detail, loading }) {
 						<span className="font-lato text-[11px] font-bold uppercase tracking-[0.6px] text-[#6C747D]">Rate Limit</span>
 						<p className="mt-[2px] font-mono font-lato text-[13px] text-[#111827]">{d.rate_limit_rpm ? `${d.rate_limit_rpm}/min` : 'Unlimited'}</p>
 					</div>
-					<div className="col-span-2">
+					<div>
+						<span className="font-lato text-[11px] font-bold uppercase tracking-[0.6px] text-[#6C747D]">Memory Policy</span>
+						<div className="mt-[4px]"><MemoryPolicyBadge policy={d.memory_policy || 'include'} /></div>
+					</div>
+					<div>
 						<span className="font-lato text-[11px] font-bold uppercase tracking-[0.6px] text-[#6C747D]">Schema Hash</span>
 						<p className="mt-[2px] font-mono font-lato text-[13px] text-[#111827] break-all">{d.schema_hash}</p>
 					</div>


### PR DESCRIPTION
Tool call and result messages are now saved to \`AppLLMMemoryMessage\` and replayed verbatim on subsequent \`agent.run()\` calls, giving the LLM full awareness of prior tool interactions within a session.

## Changes

- Tool call/result rounds persisted in session memory and rehydrated on next turn
- Added \`memory_policy\` (\`"include"\` / \`"exclude"\`) to \`@tool\` decorator and \`AppLLMTool\` model
- Migration 0002 adds \`memory_policy\` column to \`AppLLMTool\`
- \`sync_tools()\` syncs \`memory_policy\` from decorator to DB
- InvocationLogs UI: memory-injected tool calls no longer shown as live calls in current turn
- Tools UI: \`memory_policy\` badge added to tool metadata section
- Serializers expose \`memory_policy\` on list and detail endpoints

## Usage

### Default — stable lookup tools (replayed from memory)

```python
@tool(
    name="get_employee_scores",
    description="Get the employee's assessment scores.",
    section="assessments",
    # memory_policy="include" is the default — result replayed in next turns
)
def get_employee_scores(
    employee_id: int = ToolParam(description="The employee's ID"),
) -> dict:
    ...
```

On turn 2, if the user asks "what was the score?", the LLM answers from the
replayed tool result without making a new tool call.

### Exclude — side-effect tools (dropped from loaded history)

```python
@tool(
    name="send_notification",
    description="Send an email notification to the patient.",
    section="notifications",
    safety=ToolSafety.EXTERNAL,
    memory_policy="exclude",  # never replayed — prevents re-triggering side effects
)
def send_notification(
    to: str = ToolParam(description="Recipient email"),
    message: str = ToolParam(description="Message body"),
) -> dict:
    ...
```

The call is still logged in \`AppLLMToolCall\` for audit, but the assistant + tool_result
messages are dropped when loading session history so the LLM doesn't re-send it.