### PR TITLE
store invocation file attachments for audit

### DIFF
--- a/backend/src/zango/ai/agent_client.py
+++ b/backend/src/zango/ai/agent_client.py
@@ -153,6 +153,41 @@ class AgentClient:
 
         return new_messages
 
+    def _persist_invocation_files(self, invocation_id, audit_payloads):
+        """
+        Create AppLLMInvocationFile rows for an invocation.
+
+        Bytes-bearing entries are saved through ZFileField (tenant-scoped
+        storage). URL-only entries are recorded as identity rows with blob=None.
+        Fail-open: errors are logged but never re-raised — audit failures must
+        not break the agent run.
+        """
+        from django.core.files.base import ContentFile
+
+        from zango.apps.ai.models.invocation import AppLLMInvocationFile
+
+        for payload in audit_payloads:
+            try:
+                obj = AppLLMInvocationFile(
+                    invocation_id=invocation_id,
+                    sha256=payload.get("sha256", ""),
+                    size_bytes=payload.get("size_bytes", 0),
+                    media_type=payload.get("media_type", ""),
+                    filename=payload.get("filename", ""),
+                    source_kind=payload.get("source_kind", "upload"),
+                    source_url=payload.get("source_url", ""),
+                )
+                data = payload.get("data")
+                if data:
+                    name = payload.get("filename") or "upload.bin"
+                    obj.blob.save(name, ContentFile(data), save=False)
+                obj.save()
+            except Exception as e:
+                logger.error(
+                    f"Failed to persist invocation file "
+                    f"(invocation_id={invocation_id}, filename={payload.get('filename')}): {e}"
+                )
+
     def _log_tool_call(self, tool_call, result, invocation_id, round_number):
         """Log a tool execution to the AppLLMToolCall table."""
         from zango.apps.ai.models.tool import AppLLMTool, AppLLMToolCall
@@ -341,20 +376,44 @@ class AgentClient:
         #
         # Either way, after this step `msg.files` is cleared and the file
         # representation lives in `msg.content` as a permanent content block.
-        # Capture file metadata directly from the LLMFile list before prepare_files()
-        # mutates them, so the invocation log on round 1 records what was attached.
+        # Hash + capture file payloads BEFORE prepare_files() mutates them.
+        # files_meta is the lightweight summary written to the invocation's
+        # request_files JSON; audit_payloads carries the raw bytes used to
+        # create AppLLMInvocationFile rows after round 1's invocation exists.
         files_meta = None
+        audit_payloads = None
         if files:
-            files_meta = [
-                {
-                    "filename": f.filename or None,
-                    "media_type": f.media_type or None,
-                    "size_bytes": len(f.data) if f.data else None,
-                    "source": "url" if f.url else "upload",
-                    **({"url": f.url} if f.url else {}),
-                }
-                for f in files
-            ] or None
+            import hashlib
+
+            files_meta = []
+            audit_payloads = []
+            for f in files:
+                source_kind = "url" if (f.url and not f.data) else "upload"
+                size_bytes = len(f.data) if f.data else 0
+                sha256 = hashlib.sha256(f.data).hexdigest() if f.data else ""
+                files_meta.append(
+                    {
+                        "filename": f.filename or None,
+                        "media_type": f.media_type or None,
+                        "size_bytes": size_bytes or None,
+                        "sha256": sha256 or None,
+                        "source": source_kind,
+                        **({"url": f.url} if f.url else {}),
+                    }
+                )
+                audit_payloads.append(
+                    {
+                        "data": f.data,
+                        "sha256": sha256,
+                        "size_bytes": size_bytes,
+                        "media_type": f.media_type or "",
+                        "filename": f.filename or "",
+                        "source_kind": source_kind,
+                        "source_url": f.url or "",
+                    }
+                )
+            files_meta = files_meta or None
+            audit_payloads = audit_payloads or None
 
         if files:
             files = raw_provider.prepare_files(files)
@@ -395,6 +454,10 @@ class AgentClient:
                 **kwargs,
             )
             total_cost += response.cost_usd
+
+            # Persist mirrored file blobs once, after round 1's invocation row exists.
+            if round_number == 1 and audit_payloads and response.invocation_id:
+                self._persist_invocation_files(response.invocation_id, audit_payloads)
 
             # If the LLM is done (no tool calls), break
             if response.stop_reason != "tool_use" or not response.tool_calls:

--- a/backend/src/zango/api/platform/ai/v1/serializers.py
+++ b/backend/src/zango/api/platform/ai/v1/serializers.py
@@ -308,6 +308,7 @@ class AppLLMInvocationListSerializer(serializers.ModelSerializer):
 class AppLLMInvocationDetailSerializer(serializers.ModelSerializer):
     prompt_info = serializers.SerializerMethodField()
     cost_breakdown = serializers.SerializerMethodField()
+    files = serializers.SerializerMethodField()
 
     class Meta:
         model = AppLLMInvocation
@@ -327,6 +328,7 @@ class AppLLMInvocationDetailSerializer(serializers.ModelSerializer):
             "request_tools",
             "request_params",
             "request_files",
+            "files",
             "response_content",
             "response_tool_calls",
             "stop_reason",
@@ -354,6 +356,34 @@ class AppLLMInvocationDetailSerializer(serializers.ModelSerializer):
             "prompt_info",
             "cost_breakdown",
         ]
+
+    def get_files(self, obj):
+        """
+        Return the mirrored audit files for this invocation. Each entry includes
+        a presigned download URL when a blob is present, and the original URL
+        when source_kind='url' (not mirrored).
+        """
+        result = []
+        for f in obj.files.all():
+            url = ""
+            if f.blob:
+                try:
+                    url = f.blob.url
+                except Exception:
+                    url = ""
+            result.append(
+                {
+                    "id": f.id,
+                    "filename": f.filename or None,
+                    "media_type": f.media_type or None,
+                    "size_bytes": f.size_bytes or None,
+                    "sha256": f.sha256 or None,
+                    "source_kind": f.source_kind,
+                    "source_url": f.source_url or None,
+                    "url": url or None,
+                }
+            )
+        return result
 
     def get_prompt_info(self, obj):
         return {

--- a/backend/src/zango/api/platform/ai/v1/views.py
+++ b/backend/src/zango/api/platform/ai/v1/views.py
@@ -798,7 +798,9 @@ class InvocationDetailViewAPIV1(ZangoGenericPlatformAPIView):
 
     def get(self, request, app_uuid, invocation_id, *args, **kwargs):
         try:
-            invocation = AppLLMInvocation.objects.get(id=invocation_id)
+            invocation = AppLLMInvocation.objects.prefetch_related("files").get(
+                id=invocation_id
+            )
             serializer = AppLLMInvocationDetailSerializer(invocation)
             return get_api_response(True, {"invocation": serializer.data}, 200)
         except AppLLMInvocation.DoesNotExist:

--- a/backend/src/zango/apps/ai/migrations/0004_appllminvocationfile.py
+++ b/backend/src/zango/apps/ai/migrations/0004_appllminvocationfile.py
@@ -1,0 +1,103 @@
+import django.db.models.deletion
+
+from django.db import migrations, models
+
+import zango.core.storage_utils
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("ai", "0003_rename_memory_fields"),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name="AppLLMInvocationFile",
+            fields=[
+                (
+                    "id",
+                    models.AutoField(
+                        auto_created=True,
+                        primary_key=True,
+                        serialize=False,
+                        verbose_name="ID",
+                    ),
+                ),
+                ("created_at", models.DateTimeField(auto_now_add=True)),
+                (
+                    "created_by",
+                    models.CharField(blank=True, editable=False, max_length=255),
+                ),
+                ("modified_at", models.DateTimeField(auto_now=True)),
+                (
+                    "modified_by",
+                    models.CharField(blank=True, editable=False, max_length=255),
+                ),
+                (
+                    "sha256",
+                    models.CharField(
+                        blank=True,
+                        db_index=True,
+                        default="",
+                        help_text="SHA-256 of the file bytes. Empty for URL-only attachments.",
+                        max_length=64,
+                    ),
+                ),
+                (
+                    "size_bytes",
+                    models.BigIntegerField(
+                        default=0,
+                        help_text="Size of the file bytes. 0 for URL-only attachments.",
+                    ),
+                ),
+                ("media_type", models.CharField(blank=True, default="", max_length=120)),
+                ("filename", models.CharField(blank=True, default="", max_length=512)),
+                (
+                    "source_kind",
+                    models.CharField(
+                        choices=[
+                            ("upload", "Upload (django_file / bytes / path)"),
+                            ("url", "Public URL (not mirrored)"),
+                        ],
+                        max_length=20,
+                    ),
+                ),
+                (
+                    "source_url",
+                    models.URLField(
+                        blank=True,
+                        default="",
+                        help_text="Original URL when source_kind='url'.",
+                        max_length=2048,
+                    ),
+                ),
+                (
+                    "blob",
+                    zango.core.storage_utils.ZFileField(
+                        blank=True, null=True, upload_to="", validators=[]
+                    ),
+                ),
+                (
+                    "invocation",
+                    models.ForeignKey(
+                        on_delete=django.db.models.deletion.CASCADE,
+                        related_name="files",
+                        to="ai.appllminvocation",
+                    ),
+                ),
+            ],
+            options={
+                "ordering": ["invocation_id", "id"],
+                "indexes": [
+                    models.Index(
+                        fields=["sha256"],
+                        name="ai_appllmin_sha256_8bd66f_idx",
+                    ),
+                    models.Index(
+                        fields=["invocation", "id"],
+                        name="ai_appllmin_invocat_f9363f_idx",
+                    ),
+                ],
+            },
+        ),
+    ]

--- a/backend/src/zango/apps/ai/models/__init__.py
+++ b/backend/src/zango/apps/ai/models/__init__.py
@@ -1,5 +1,5 @@
 from .agent import AppLLMAgent
-from .invocation import AppLLMInvocation
+from .invocation import AppLLMInvocation, AppLLMInvocationFile
 from .memory import AppLLMMemoryMessage, AppLLMMemorySession
 from .prompt import AppLLMPrompt, AppLLMPromptVersion
 from .provider import AppLLMProvider, AppLLMProviderModel
@@ -9,6 +9,7 @@ from .tool import AppLLMTool, AppLLMToolCall
 __all__ = [
     "AppLLMAgent",
     "AppLLMInvocation",
+    "AppLLMInvocationFile",
     "AppLLMMemoryMessage",
     "AppLLMMemorySession",
     "AppLLMPrompt",

--- a/backend/src/zango/apps/ai/models/invocation.py
+++ b/backend/src/zango/apps/ai/models/invocation.py
@@ -9,6 +9,7 @@ Log entries are immutable — never updated after creation (append-only).
 from django.db import models
 
 from zango.core.model_mixins import FullAuditMixin
+from zango.core.storage_utils import ZFileField
 
 
 class AppLLMInvocation(FullAuditMixin):
@@ -161,3 +162,65 @@ class AppLLMInvocation(FullAuditMixin):
         return (
             f"Invocation {self.pk} - {self.provider_name}/{self.model} ({self.status})"
         )
+
+
+class AppLLMInvocationFile(FullAuditMixin):
+    """
+    A file attached to an LLM invocation. Mirrors what the model actually saw.
+
+    One row per LLMFile passed to agent.run() / provider.complete(). Only round 1
+    of an agent run creates rows — subsequent rounds re-use the same content.
+
+    The `blob` field stores the actual bytes via the tenant's storage backend.
+    For URL-only attachments (LLMFile.from_url), blob is null and only
+    source_url is recorded. Identity fields (sha256, size_bytes, media_type)
+    are kept even if the blob is later purged by a retention policy.
+    """
+
+    SOURCE_CHOICES = [
+        ("upload", "Upload (django_file / bytes / path)"),
+        ("url", "Public URL (not mirrored)"),
+    ]
+
+    invocation = models.ForeignKey(
+        AppLLMInvocation,
+        on_delete=models.CASCADE,
+        related_name="files",
+    )
+
+    # Identity — preserved forever, even if blob is purged
+    sha256 = models.CharField(
+        max_length=64,
+        db_index=True,
+        help_text="SHA-256 of the file bytes. Empty for URL-only attachments.",
+        blank=True,
+        default="",
+    )
+    size_bytes = models.BigIntegerField(
+        default=0, help_text="Size of the file bytes. 0 for URL-only attachments."
+    )
+    media_type = models.CharField(max_length=120, blank=True, default="")
+    filename = models.CharField(max_length=512, blank=True, default="")
+
+    source_kind = models.CharField(max_length=20, choices=SOURCE_CHOICES)
+    source_url = models.URLField(
+        max_length=2048,
+        blank=True,
+        default="",
+        help_text="Original URL when source_kind='url'.",
+    )
+
+    # The mirrored bytes — null for URL-only attachments or after retention purge.
+    # validators=[] bypasses ZFileField's hardcoded extension allowlist, since
+    # LLM attachments can legitimately be any media type.
+    blob = ZFileField(null=True, blank=True, validators=[])
+
+    class Meta:
+        ordering = ["invocation_id", "id"]
+        indexes = [
+            models.Index(fields=["sha256"]),
+            models.Index(fields=["invocation", "id"]),
+        ]
+
+    def __str__(self):
+        return f"InvocationFile {self.pk} ({self.filename or self.sha256[:12] or self.source_url})"

--- a/backend/src/zango/tests/apps/ai/test_agent_client.py
+++ b/backend/src/zango/tests/apps/ai/test_agent_client.py
@@ -14,7 +14,7 @@ from django.test import SimpleTestCase
 
 from zango.ai.agent_client import AgentClient
 from zango.ai.exceptions import AgentDisabled
-from zango.ai.providers.base import LLMMessage, LLMResponse, LLMToolCall, LLMUsage
+from zango.ai.providers.base import LLMFile, LLMMessage, LLMResponse, LLMToolCall, LLMUsage
 
 # ─── Helpers ─────────────────────────────────────────────────────────────────
 
@@ -150,7 +150,9 @@ class InputResolutionTest(SimpleTestCase):
     def test_files_only_no_text_creates_empty_content_message(self):
         agent = _make_agent()
         agent.get_user_prompt_content.return_value = ""
-        file_mock = MagicMock()
+        file_mock = MagicMock(spec=LLMFile)
+        file_mock.data = None
+        file_mock.url = None
         file_mock.to_anthropic_block.return_value = {"type": "image", "source": {}}
 
         with patch(_PC) as mock_pc_cls:
@@ -173,7 +175,9 @@ class InputResolutionTest(SimpleTestCase):
             LLMMessage(role="assistant", content="reply"),
             LLMMessage(role="user", content="second"),
         ]
-        file_mock = MagicMock()
+        file_mock = MagicMock(spec=LLMFile)
+        file_mock.data = None
+        file_mock.url = None
         file_mock.to_anthropic_block.return_value = {"type": "image", "source": {}}
         with patch(_PC) as mock_pc_cls:
             mock_pc = MagicMock()
@@ -191,7 +195,9 @@ class InputResolutionTest(SimpleTestCase):
     def test_files_creates_new_user_message_when_no_user_message_in_explicit(self):
         agent = _make_agent()
         explicit = [LLMMessage(role="assistant", content="reply")]
-        file_mock = MagicMock()
+        file_mock = MagicMock(spec=LLMFile)
+        file_mock.data = None
+        file_mock.url = None
         with patch(_PC) as mock_pc_cls:
             mock_pc = MagicMock()
             mock_pc.complete.return_value = _make_response()

--- a/frontend/src/pages/appAi/components/InvocationLogs.jsx
+++ b/frontend/src/pages/appAi/components/InvocationLogs.jsx
@@ -296,28 +296,79 @@ function InvocationDetail({ invocation }) {
 							</div>
 						)}
 
-						{/* Files attached */}
-						{invocation.request_files && invocation.request_files.length > 0 && (
-							<div className="flex items-center gap-[8px] rounded-[8px] border border-[#E5E7EB] bg-[#F9FAFB] px-[12px] py-[10px]">
-								<span className="text-[14px]">📎</span>
-								{invocation.request_files.map((f, i) => (
-									<span key={i} className="flex items-center gap-[6px]">
-										<span className="font-lato text-[12px] font-medium text-[#111827]">{f.filename?.split('/').pop() || 'file'}</span>
-										<span className="rounded-full bg-[#EFF6FF] px-[6px] py-[1px] font-lato text-[10px] text-[#2563EB]">{f.media_type}</span>
-										{f.size_bytes != null && (
-											<span className="font-lato text-[11px] text-[#9CA3AF]">
-												{f.size_bytes >= 1048576 ? `${(f.size_bytes / 1048576).toFixed(1)}MB`
-													: f.size_bytes >= 1024 ? `${(f.size_bytes / 1024).toFixed(1)}KB`
-													: `${f.size_bytes}B`}
-											</span>
-										)}
-									</span>
-								))}
-								{hasFileBlocks && !invocation.request_files.length && (
-									<span className="font-lato text-[12px] text-[#6B7280]">File included in message</span>
-								)}
-							</div>
-						)}
+						{/* Files attached — prefer rich audit rows (invocation.files), fall back to legacy summary */}
+						{(() => {
+							const richFiles = invocation.files || [];
+							const legacyFiles = !richFiles.length ? (invocation.request_files || []) : [];
+							const allFiles = richFiles.length ? richFiles : legacyFiles;
+							if (!allFiles.length) {
+								return hasFileBlocks ? (
+									<div className="flex items-center gap-[8px] rounded-[8px] border border-[#E5E7EB] bg-[#F9FAFB] px-[12px] py-[10px]">
+										<span className="text-[14px]">📎</span>
+										<span className="font-lato text-[12px] text-[#6B7280]">File included in message</span>
+									</div>
+								) : null;
+							}
+							const fmtSize = (n) => n == null ? null
+								: n >= 1048576 ? `${(n / 1048576).toFixed(1)}MB`
+								: n >= 1024 ? `${(n / 1024).toFixed(1)}KB`
+								: `${n}B`;
+							return (
+								<div className="rounded-[8px] border border-[#E5E7EB] bg-[#F9FAFB] px-[12px] py-[10px]">
+									<div className="mb-[6px] flex items-center gap-[6px]">
+										<span className="text-[14px]">📎</span>
+										<span className="font-lato text-[11px] font-bold uppercase tracking-[0.6px] text-[#6B7280]">
+											Attached files ({allFiles.length})
+										</span>
+									</div>
+									<div className="flex flex-col gap-[6px]">
+										{allFiles.map((f, i) => {
+											const filename = (f.filename || '').split('/').pop() || 'file';
+											const href = f.url || f.source_url || null;
+											const size = fmtSize(f.size_bytes);
+											const sha = f.sha256 ? f.sha256.slice(0, 12) : null;
+											const sourceLabel = f.source_kind === 'url' ? 'URL (not mirrored)'
+												: f.source_kind === 'upload' ? 'Mirrored' : null;
+											return (
+												<div key={f.id ?? i} className="flex flex-wrap items-center gap-[8px]">
+													{href ? (
+														<a
+															href={href}
+															target="_blank"
+															rel="noopener noreferrer"
+															className="font-lato text-[12px] font-medium text-[#2563EB] underline hover:text-[#1D4ED8]"
+														>
+															{filename}
+														</a>
+													) : (
+														<span className="font-lato text-[12px] font-medium text-[#111827]">{filename}</span>
+													)}
+													{f.media_type && (
+														<span className="rounded-full bg-[#EFF6FF] px-[6px] py-[1px] font-lato text-[10px] text-[#2563EB]">
+															{f.media_type}
+														</span>
+													)}
+													{size && (
+														<span className="font-lato text-[11px] text-[#9CA3AF]">{size}</span>
+													)}
+													{sourceLabel && (
+														<span className="font-lato text-[10px] text-[#6B7280]">· {sourceLabel}</span>
+													)}
+													{sha && (
+														<span
+															className="font-mono text-[10px] text-[#9CA3AF]"
+															title={`sha256: ${f.sha256}`}
+														>
+															sha {sha}…
+														</span>
+													)}
+												</div>
+											);
+										})}
+									</div>
+								</div>
+							);
+						})()}
 
 						{/* Memory history context — collapsible, shows prior exchanges loaded from memory */}
 						{hasMemoryHistory && (


### PR DESCRIPTION
Add AppLLMInvocationFile child model that mirrors each LLMFile attached to an agent run. Bytes-bearing sources (django_file, raw bytes, path, Anthropic fallback) are saved via ZFileField into the tenant's storage; URL-only attachments are recorded as identity rows with source_url and blob=None. Identity fields (sha256, size_bytes, media_type, filename) are kept even if the blob is later purged.

Hashing and persistence happen once per agent.run(), before prepare_files() mutates the LLMFile list. Failures are logged but never raised so audit issues can't break the agent. Invocation detail API exposes a new `files` field with presigned download URLs; the panel renders each as a hyperlink.