### PR TITLE
fix(auditlogs): audit log gap for direct-imported workspace models

### DIFF
--- a/backend/src/zango/apps/auditlogs/apps.py
+++ b/backend/src/zango/apps/auditlogs/apps.py
@@ -1,5 +1,61 @@
 from django.apps import AppConfig
+from django.db.models.signals import class_prepared
 from django.utils.translation import gettext_lazy as _
+
+
+def _auto_register_workspace_model(sender, **kwargs):
+    """Register any workspace model with auditlog at the moment its class
+    statement finishes executing.
+
+    Background:
+    ``Workspace.load_models()`` is the only place that calls
+    ``auditlog.register(model)`` for workspace models, and it walks the
+    set of models produced by **pluginbase's** loader. Each loader run
+    creates fresh class objects in its own namespace; ``signal.connect``
+    pins the receiver to that specific class object.
+
+    A direct import — ``from workspaces.<app>.<package>.models import X``
+    in a Django shell, in code execution snippets, in management
+    commands — bypasses pluginbase and produces a *different* class
+    object. The audit registration never ran against it, so saves on
+    instances of that class silently skip the audit log.
+
+    Hooking Django's ``class_prepared`` signal closes the gap: every
+    DynamicModelBase subclass gets registered exactly once per class
+    object, the moment that class object is constructed, regardless of
+    which loader (pluginbase, stdlib import, importlib) produced it.
+    """
+    # Lazy imports — this runs during Django boot before the apps
+    # registry is fully populated. DynamicModelBase is a Django model
+    # itself; importing it eagerly at module load would create a cycle
+    # via AppConfig.ready().
+    from zango.apps.auditlogs.registry import auditlog
+    from zango.apps.dynamic_models.models import DynamicModelBase
+
+    if sender is DynamicModelBase:
+        return
+    try:
+        if not issubclass(sender, DynamicModelBase):
+            return
+    except TypeError:
+        # `sender` wasn't a class (defensive — shouldn't happen for
+        # class_prepared, but guards against unexpected emitters).
+        return
+
+    if auditlog.contains(sender):
+        return
+
+    meta = getattr(sender, "DynamicModelMeta", None)
+    if meta is not None and getattr(meta, "exclude_audit_log", False):
+        return
+
+    excluded_fields = (
+        getattr(meta, "exclude_audit_log_fields", None) if meta is not None else None
+    )
+    if excluded_fields:
+        auditlog.register(sender, exclude_fields=excluded_fields)
+    else:
+        auditlog.register(sender)
 
 
 class AuditlogConfig(AppConfig):
@@ -15,3 +71,13 @@ class AuditlogConfig(AppConfig):
         from zango.apps.auditlogs import models
 
         models.changes_func = models._changes_func()
+
+        # Auto-register every workspace model regardless of import path
+        # — fixes audit-log gaps in Django shell, code execution
+        # snippets, and any other entry point that bypasses
+        # ``Workspace.load_models()``. See `_auto_register_workspace_model`
+        # docstring for details.
+        class_prepared.connect(
+            _auto_register_workspace_model,
+            dispatch_uid="zango.auditlogs.auto_register_workspace_model",
+        )


### PR DESCRIPTION
## The bug

Saves on workspace models silently skip audit logs when the model is reached via direct import — Django shell, code execution snippets, management commands — but log correctly when reached via the pluginbase loader.

Both paths hit the same database table; only the audit log differs.

## Root cause

\`Workspace.load_models()\` is the only place that calls \`auditlog.register(model)\` for workspace models, and the registration attaches signals with \`sender=<specific class object>\`:

\`\`\`python
# workspace/base.py:272 — pluginbase loader
module = self.plugin_source.load_plugin(".".join(split))
for name, obj in inspect.getmembers(module):
    if issubclass(obj, DynamicModelBase) and obj != DynamicModelBase:
        auditlog.register(obj)                           # ← signal wired to obj
\`\`\`

\`\`\`python
# auditlogs/registry.py:200
signal.connect(receiver, sender=model, ...)              # ← pinned to class object
\`\`\`

Pluginbase loads each tenant's \`models.py\` into its own private namespace. A direct import (\`from workspaces.x.models import Doctor\`) loads the same file through the standard Python import system into a *different* namespace, producing a **different class object** in memory. Same database table, but \`id(pluginbase_Doctor) != id(direct_Doctor)\`. Audit signals are wired to the pluginbase variant; saves on the direct-import variant fire \`post_save\` with a sender Django has no handler for. Audit silently doesn't write.

This is also why Django shell exhibits the same bug — shell never runs \`Workspace.ready()\`.

## The fix

Hook Django's \`class_prepared\` signal in \`AuditlogConfig.ready()\` and auto-register every \`DynamicModelBase\` subclass at the moment its class statement finishes executing. Each loader (pluginbase, stdlib import, importlib) emits \`class_prepared\` for the class object it produced — our receiver registers that specific class object with the audit registry.

Both class objects end up registered, both have signal handlers attached, audit fires regardless of import path.

## Why \`class_prepared\` is the right hook

- Fires **once per class object, per process**, exactly when the class statement finishes
- Already produces the model class as \`sender\` — exactly what \`auditlog.register\` needs
- Lazily evaluated: a workspace model that's never loaded never costs anything
- Covers every present and future code path that bypasses pluginbase

## Why not the alternatives

**Wrap codexec code in a pluginbase loader.** Fixes codexec but not Django shell, not management commands, not future direct-import paths. Also adds executor complexity for what is essentially "inherit a side effect of going through the right loader" — wrong lever.

**Move the existing loop to a shared helper.** Doesn't help — the problem is *when* the registration runs, not where.

## What stays unchanged

\`Workspace.load_models()\`'s explicit \`auditlog.register\` loop is left in place as a fallback. \`auditlog.register\` short-circuits via the \`if cls in self._registry.keys(): return cls\` check in \`registry.py:122\`, so double-registration is a no-op. Trimming the loop can be a follow-up.

## Memory implications

Negligible. ~1-2 KB per extra registered class object (registry entry + 4 signal connections). A workspace with 500 models fully direct-imported is ~1 MB per worker. The receiver is gated by \`issubclass(sender, DynamicModelBase)\` so non-workspace models (Django built-ins, third-party apps, Zango platform models that register themselves) are skipped at near-zero cost.

## Performance footprint

- \`class_prepared.connect(...)\` runs once at server boot.
- Receiver fires once per workspace model per Python process, the first time the model class is loaded.
- After that, normal Django signal dispatch — no extra cost per save.

## Test plan

- [ ] Django shell: \`from workspaces.<tenant>.<app>.models import Doctor\`, modify a field, save → audit log entry should appear.
- [ ] Django shell via pluginbase (the existing-working path): same save through \`ws.plugin_source.load_plugin(...).Doctor\` should continue to log audit.
- [ ] Codexec: run a snippet that does \`from workspaces.<tenant>.<app>.models import Doctor\` and saves an instance → audit log entry should appear.
- [ ] Normal HTTP request flow: workspace requests still produce audit log entries (no regression on the pluginbase path).
- [ ] Models with \`DynamicModelMeta.exclude_audit_log = True\` still skip audit.
- [ ] Models with \`DynamicModelMeta.exclude_audit_log_fields\` still respect the field exclusion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)