### PR TITLE
fix(ai): wire agent timeout_seconds through to provider API calls

### DIFF
--- a/backend/src/zango/ai/agent_client.py
+++ b/backend/src/zango/ai/agent_client.py
@@ -451,6 +451,7 @@ class AgentClient:
                 run_id=run_id,
                 round_number=round_number,
                 request_files_meta=files_meta if round_number == 1 else None,
+                timeout_seconds=self._agent.timeout_seconds,
                 **{**agent_tracking},
                 **response_format_kwarg,
                 **kwargs,

--- a/backend/src/zango/ai/client.py
+++ b/backend/src/zango/ai/client.py
@@ -223,6 +223,10 @@ class ProviderClient:
         agent_kwargs = {k: kwargs.pop(k) for k in agent_fields if k in kwargs}
         return agent_kwargs
 
+    def _extract_timeout(self, kwargs):
+        """Pop and return timeout_seconds from kwargs (default None = provider default)."""
+        return kwargs.pop("timeout_seconds", None)
+
     def complete(
         self,
         messages: list[LLMMessage],
@@ -240,6 +244,7 @@ class ProviderClient:
         """
         # Extract agent tracking kwargs before passing rest to provider
         agent_kwargs = self._extract_agent_kwargs(kwargs)
+        timeout_seconds = self._extract_timeout(kwargs)
 
         model = self._resolve_model(model)
         self._check_model_enabled(model)
@@ -252,6 +257,10 @@ class ProviderClient:
         if stop_sequences:
             params["stop_sequences"] = stop_sequences
 
+        provider_kwargs = dict(kwargs)
+        if timeout_seconds is not None:
+            provider_kwargs["timeout_seconds"] = timeout_seconds
+
         try:
             response = client.complete(
                 messages=messages,
@@ -261,7 +270,7 @@ class ProviderClient:
                 max_tokens=max_tokens,
                 system=system,
                 stop_sequences=stop_sequences,
-                **kwargs,
+                **provider_kwargs,
             )
 
             # Compute cost

--- a/backend/src/zango/ai/providers/anthropic.py
+++ b/backend/src/zango/ai/providers/anthropic.py
@@ -306,15 +306,17 @@ class AnthropicProvider(BaseLLMProvider):
             )
 
         uses_files_beta = self._needs_files_beta(kwargs_api["messages"])
+        timeout = kwargs.get("timeout_seconds")
 
         start = time.monotonic()
         try:
+            create_kwargs = {"timeout": timeout} if timeout is not None else {}
             if uses_files_beta:
                 response = self._client.beta.messages.create(
-                    **kwargs_api, betas=["files-api-2025-04-14"]
+                    **kwargs_api, betas=["files-api-2025-04-14"], **create_kwargs
                 )
             else:
-                response = self._client.messages.create(**kwargs_api)
+                response = self._client.messages.create(**kwargs_api, **create_kwargs)
         except self._anthropic.RateLimitError as e:
             raise RateLimitExceeded(str(e)) from e
         except self._anthropic.APITimeoutError as e:
@@ -386,14 +388,16 @@ class AnthropicProvider(BaseLLMProvider):
             )
 
         uses_files_beta = self._needs_files_beta(kwargs_api["messages"])
+        timeout = kwargs.get("timeout_seconds")
+        stream_kwargs = {"timeout": timeout} if timeout is not None else {}
 
         try:
             _stream_ctx = (
                 self._client.beta.messages.stream(
-                    **kwargs_api, betas=["files-api-2025-04-14"]
+                    **kwargs_api, betas=["files-api-2025-04-14"], **stream_kwargs
                 )
                 if uses_files_beta
-                else self._client.messages.stream(**kwargs_api)
+                else self._client.messages.stream(**kwargs_api, **stream_kwargs)
             )
             with _stream_ctx as stream:
                 for event in stream:

--- a/backend/src/zango/ai/providers/azure_openai.py
+++ b/backend/src/zango/ai/providers/azure_openai.py
@@ -135,6 +135,10 @@ class AzureOpenAIProvider(BaseLLMProvider):
         elif response_format == "json":
             api_kwargs["response_format"] = {"type": "json_object"}
 
+        timeout = kwargs.get("timeout_seconds")
+        if timeout is not None:
+            api_kwargs["timeout"] = timeout
+
         start = time.monotonic()
         try:
             response = self._client.chat.completions.create(**api_kwargs)
@@ -200,6 +204,10 @@ class AzureOpenAIProvider(BaseLLMProvider):
             api_kwargs["tools"] = self.format_tools_for_api(tools)
         if stop_sequences:
             api_kwargs["stop"] = stop_sequences
+
+        timeout = kwargs.get("timeout_seconds")
+        if timeout is not None:
+            api_kwargs["timeout"] = timeout
 
         try:
             stream = self._client.chat.completions.create(**api_kwargs)

--- a/backend/src/zango/ai/providers/openai.py
+++ b/backend/src/zango/ai/providers/openai.py
@@ -283,6 +283,10 @@ class OpenAIProvider(BaseLLMProvider):
         elif response_format == "json":
             api_kwargs["response_format"] = {"type": "json_object"}
 
+        timeout = kwargs.get("timeout_seconds")
+        if timeout is not None:
+            api_kwargs["timeout"] = timeout
+
         start = time.monotonic()
         try:
             response = self._client.chat.completions.create(**api_kwargs)
@@ -348,6 +352,10 @@ class OpenAIProvider(BaseLLMProvider):
             api_kwargs["tools"] = self.format_tools_for_api(tools)
         if stop_sequences:
             api_kwargs["stop"] = stop_sequences
+
+        timeout = kwargs.get("timeout_seconds")
+        if timeout is not None:
+            api_kwargs["timeout"] = timeout
 
         try:
             stream = self._client.chat.completions.create(**api_kwargs)


### PR DESCRIPTION
The AppLLMAgent.timeout_seconds field was stored in the DB but never forwarded to the underlying SDK — Anthropic used its provider-level init timeout (120s), OpenAI/Azure used the SDK default (600s).

- AgentClient.run(): passes timeout_seconds=self._agent.timeout_seconds into every provider_client.complete() call
- ProviderClient: adds _extract_timeout() to pop the value from kwargs and forwards it to the raw provider complete()
- AnthropicProvider: passes timeout= per-call to messages.create() / messages.stream() (both standard and files-beta paths)
- OpenAIProvider / AzureOpenAIProvider: injects timeout= into api_kwargs for both complete() and stream()