### PR TITLE
fix(auditlog): make audit log multi-tenant safe + non-blocking

### DIFF
--- a/backend/src/zango/apps/auditlogs/diff.py
+++ b/backend/src/zango/apps/auditlogs/diff.py
@@ -1,5 +1,4 @@
 import json
-import logging
 
 from datetime import timezone
 from typing import Optional
@@ -17,11 +16,9 @@ from django.db.models import (
 from django.db.utils import DatabaseError
 from django.utils import timezone as django_timezone
 from django.utils.encoding import smart_str
+from loguru import logger
 
 from zango.apps.dynamic_models.fields import ZForeignKey, ZOneToOneField
-
-
-logger = logging.getLogger("zango.auditlogs")
 
 
 def track_field(field):
@@ -147,7 +144,7 @@ def get_field_value(obj, field):
         # Audit log must not break the host operation — degrade to None
         # with a warning so the failure is observable but non-fatal.
         logger.warning(
-            "Audit-log field read failed for %s.%s: %s",
+            "Audit-log field read failed for {}.{}: {}",
             type(obj).__name__,
             getattr(field, "name", "?"),
             e,

--- a/backend/src/zango/apps/auditlogs/diff.py
+++ b/backend/src/zango/apps/auditlogs/diff.py
@@ -1,4 +1,5 @@
 import json
+import logging
 
 from datetime import timezone
 from typing import Optional
@@ -13,10 +14,14 @@ from django.db.models import (
     Model,
     OneToOneField,
 )
+from django.db.utils import DatabaseError
 from django.utils import timezone as django_timezone
 from django.utils.encoding import smart_str
 
 from zango.apps.dynamic_models.fields import ZForeignKey, ZOneToOneField
+
+
+logger = logging.getLogger("zango.auditlogs")
 
 
 def track_field(field):
@@ -34,6 +39,19 @@ def track_field(field):
 
     # Do not track many to many relations
     if field.many_to_many:
+        return False
+
+    # Do not track REVERSE relations (auto-created accessors on the target
+    # side of a FK / OneToOne). These point at OTHER rows; their changes
+    # belong to the audit log of the model that holds the FK. Including
+    # them here triggers eager DB lookups on every save which in
+    # multi-tenant dynamic-model setups can hit tables that don't exist
+    # in the current schema. The `auto_created=True, concrete=False`
+    # pair is Django's canonical marker for these auto-generated
+    # reverse descriptors.
+    if getattr(field, "auto_created", False) and not getattr(
+        field, "concrete", True
+    ):
         return False
 
     # Do not track relations to LogEntry
@@ -123,6 +141,18 @@ def get_field_value(obj, field):
             if getattr(field, "default", NOT_PROVIDED) is not NOT_PROVIDED
             else None
         )
+    except DatabaseError as e:
+        # Tenant-scoped dynamic model not migrated in this schema, or any
+        # other DB-level read failure surfacing through a lazy descriptor.
+        # Audit log must not break the host operation — degrade to None
+        # with a warning so the failure is observable but non-fatal.
+        logger.warning(
+            "Audit-log field read failed for %s.%s: %s",
+            type(obj).__name__,
+            getattr(field, "name", "?"),
+            e,
+        )
+        value = None
 
     return value
 

--- a/backend/src/zango/apps/auditlogs/receivers.py
+++ b/backend/src/zango/apps/auditlogs/receivers.py
@@ -1,3 +1,5 @@
+import logging
+
 from functools import wraps
 
 from django.conf import settings
@@ -6,6 +8,9 @@ from zango.apps.auditlogs.context import auditlog_disabled
 from zango.apps.auditlogs.diff import model_instance_diff
 from zango.apps.auditlogs.models import LogEntry
 from zango.apps.auditlogs.signals import post_log, pre_log
+
+
+logger = logging.getLogger("zango.auditlogs")
 
 
 def check_disable(signal_handler):
@@ -143,7 +148,21 @@ def _create_log_entry(
                 log_created=log_entry is not None,
             )
         if error:
-            raise error
+            # Audit log is a trace, not a transactional dependency. A
+            # missing log row is far less serious than aborting the host
+            # operation, so we log the failure as a warning and swallow.
+            # Dev environments can flip AUDITLOG_RAISE_ERRORS=True in
+            # settings to surface internal failures loudly.
+            logger.warning(
+                "Audit-log %s failed for %s pk=%s: %s",
+                action,
+                sender.__name__,
+                getattr(instance, "pk", "?"),
+                error,
+                exc_info=True,
+            )
+            if getattr(settings, "AUDITLOG_RAISE_ERRORS", False):
+                raise error
 
 
 def make_log_m2m_changes(field_name):

--- a/backend/src/zango/apps/auditlogs/receivers.py
+++ b/backend/src/zango/apps/auditlogs/receivers.py
@@ -1,16 +1,12 @@
-import logging
-
 from functools import wraps
 
 from django.conf import settings
+from loguru import logger
 
 from zango.apps.auditlogs.context import auditlog_disabled
 from zango.apps.auditlogs.diff import model_instance_diff
 from zango.apps.auditlogs.models import LogEntry
 from zango.apps.auditlogs.signals import post_log, pre_log
-
-
-logger = logging.getLogger("zango.auditlogs")
 
 
 def check_disable(signal_handler):
@@ -153,13 +149,12 @@ def _create_log_entry(
             # operation, so we log the failure as a warning and swallow.
             # Dev environments can flip AUDITLOG_RAISE_ERRORS=True in
             # settings to surface internal failures loudly.
-            logger.warning(
-                "Audit-log %s failed for %s pk=%s: %s",
+            logger.opt(exception=True).warning(
+                "Audit-log {} failed for {} pk={}: {}",
                 action,
                 sender.__name__,
                 getattr(instance, "pk", "?"),
                 error,
-                exc_info=True,
             )
             if getattr(settings, "AUDITLOG_RAISE_ERRORS", False):
                 raise error


### PR DESCRIPTION
## The bug

Creating an \`AppUser\` in a tenant whose schema doesn't have a related dynamic-model table raises \`UndefinedTable\` (\`relation \"dynamic_models_<...>\" does not exist\`), with the traceback going through Zango's audit-log \`post_save\` handler. The host operation aborts even though the audit log is supposed to be a passive trace.

### Reproduction

Tenant A defines a dynamic model with \`OneToOneField(AppUserModel, related_name=\"profile\")\`. This registers a \`profile\` **reverse descriptor** on \`AppUserModel\` at the Python class level — process-wide, all tenants share it. Now create an \`AppUser\` in Tenant B whose schema never migrated that dynamic model:

1. \`post_save\` fires
2. Audit-log handler walks \`app_user._meta.get_fields()\`
3. Hits the \`profile\` reverse field
4. \`getattr(app_user, \"profile\")\` runs \`SELECT … FROM dynamic_models_profile WHERE user_id = …\` against Tenant B's schema
5. Table doesn't exist → \`UndefinedTable\` → audit handler re-raises → host save aborts

## Root cause

Three problems compound:

1. **Reverse relations shouldn't be in the diff at all.** They describe *other rows pointing at this row*; their changes belong to the audit log of the model that holds the FK. Including them is semantically wrong.
2. **OneToOne reverse access is eager.** \`getattr(obj, \"profile\")\` runs a SQL query immediately; ForeignKey reverse access returns a manager (lazy). So the bug surfaces on O2O and stays latent on FK.
3. **The audit-log handler re-raises any internal exception**, so its own bugs abort the host \`post_save\` chain.

## The fix

Three changes across two files (~15 LOC):

### Fix #1 — \`diff.py::track_field\` (root cause)
Skip reverse relations using Django's canonical marker (\`auto_created=True, concrete=False\`). Forward FKs/O2Os keep \`auto_created=False, concrete=True\` and are unaffected.

### Fix #2 — \`diff.py::get_field_value\` (defense in depth)
Catch \`django.db.utils.DatabaseError\` so any descriptor that errors at read time degrades to \`None\` with a WARNING log instead of propagating. Covers \`UndefinedTable\`, \`OperationalError\`, \`ProgrammingError\`, \`IntegrityError\` — all share that base class.

### Fix #3 — \`receivers.py::_create_log_entry\` (policy)
Stop re-raising on internal failures by default. Logs at WARNING via the \`zango.auditlogs\` logger so failures are observable. Exposes an \`AUDITLOG_RAISE_ERRORS\` settings flag (default off) for dev environments that want loud failures.

## Behavior change

**Exactly:** stop reading reverse-side relation accessors during diffs, and stop letting audit-log internals abort the host operation. Concrete scalar fields, JSON, forward FKs, forward O2Os, datetime — all behave identically.

## Performance side-benefit

A model with N reverse-O2O accessors was firing N eager DB queries on every save just to populate the audit-log diff. This goes away.

## Test plan

- [ ] Create an \`AppUser\` in a tenant with no related dynamic models — succeeds, audit log row written
- [ ] Create an \`AppUser\` in a tenant where another tenant defines a reverse O2O — succeeds (previously crashed), audit log row written, \`changes\` dict does NOT contain the reverse field
- [ ] Update an existing \`AppUser\` — audit log row written with correct \`changes\` for concrete fields
- [ ] Delete an existing \`AppUser\` — audit log row written
- [ ] \`AUDITLOG_RAISE_ERRORS=True\` in dev settings → an induced audit-log failure raises
- [ ] Default (\`AUDITLOG_RAISE_ERRORS\` unset) → an induced audit-log failure logs WARNING + swallows
- [ ] Audited models with explicit \`include_fields\` / \`exclude_fields\` configs still respect them

## Files touched

\`backend/src/zango/apps/auditlogs/diff.py\` (+30 / -0)
\`backend/src/zango/apps/auditlogs/receivers.py\` (+21 / -1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)