### PR TITLE
fix(dynamic_models): defer pending-op resolution in Z*Field contribute_to_class

### DIFF
--- a/backend/src/zango/apps/dynamic_models/fields/__init__.py
+++ b/backend/src/zango/apps/dynamic_models/fields/__init__.py
@@ -2,63 +2,102 @@ import sys
 
 from django.conf import settings
 from django.db import models
+from django.db.models.signals import class_prepared
 
 
 # from django.utils.translation import gettext_lazy as _
 
 
+# Argv guards that disable the runtime apps fix-up. Migration / fixture
+# commands run their own model-resolution machinery and don't need (or
+# want) this codepath.
+_RUNTIME_GUARD_ARGS = (
+    "ws_migrate",
+    "ws_makemigration",
+    "export_fixture",
+    "import_fixture",
+    "update-apps",
+)
+
+
+def _runtime_active() -> bool:
+    """True when we're in a normal request-serving / worker context —
+    i.e. not running one of the migration / fixture management commands
+    listed in `_RUNTIME_GUARD_ARGS`, and not inside a TEST_MIGRATION_RUNNING
+    block."""
+    return all(arg not in sys.argv for arg in _RUNTIME_GUARD_ARGS) and not getattr(
+        settings, "TEST_MIGRATION_RUNNING", False
+    )
+
+
+def _defer_pending_operations(cls, *related_models):
+    """Schedule `apps.do_pending_operations` calls to fire after `cls`
+    is fully prepared.
+
+    Calling `apps.do_pending_operations(cls)` from inside a field's
+    `contribute_to_class` fires queued pending operations against `cls`
+    BEFORE `cls._meta.concrete_model` is set by `_prepare()`. Pending
+    operations typically end up calling
+    `setattr(cls._meta.concrete_model, accessor_name, descriptor)` —
+    `concrete_model` is `None` at that point, so `setattr(None, ...)`
+    raises `AttributeError` and breaks the class definition.
+
+    Django emits `class_prepared` for each model after `Options._prepare`
+    has set `concrete_model`. By attaching the pending-op resolution to
+    that signal we run it at the first moment it's safe. The receiver
+    disconnects itself after firing so we don't accumulate dead handlers
+    on the global signal.
+
+    `weak=False` keeps the inner closure alive between `connect` and
+    the imminent `send` — without it Python would garbage-collect the
+    closure as soon as `contribute_to_class` returns.
+    """
+    if not related_models:
+        related_models = ()
+
+    def _resolve_pending(sender, **kwargs):
+        try:
+            apps = sender._meta.apps
+            apps.do_pending_operations(sender)
+            for related in related_models:
+                if related is None:
+                    continue
+                try:
+                    apps.do_pending_operations(related)
+                except Exception:
+                    # related may still be a string ref or otherwise
+                    # unresolvable; skip rather than break sender's prep.
+                    pass
+            apps.clear_cache()
+        finally:
+            class_prepared.disconnect(_resolve_pending, sender=sender)
+
+    class_prepared.connect(_resolve_pending, sender=cls, weak=False)
+
+
 class ZForeignKey(models.ForeignKey):
     def contribute_to_class(self, cls, related):
         super().contribute_to_class(cls, related)
-        if all(
-            arg not in sys.argv
-            for arg in (
-                "ws_migrate",
-                "ws_makemigration",
-                "export_fixture",
-                "import_fixture",
-                "update-apps",
-            )
-        ) and not getattr(settings, "TEST_MIGRATION_RUNNING", False):
+        if _runtime_active():
             cls._meta.apps.add_models(cls, self.related_model)
             try:
                 self.related_model._meta.apps.add_models(self.related_model, cls)
             except Exception:
                 pass
-
-            apps = cls._meta.apps
-            apps.do_pending_operations(cls)
-            apps.do_pending_operations(self.related_model)
-            apps.clear_cache()
+            _defer_pending_operations(cls, self.related_model)
 
 
 class ZOneToOneField(models.OneToOneField):
     def contribute_to_class(self, cls, related):
         super().contribute_to_class(cls, related)
-        if all(
-            arg not in sys.argv
-            for arg in (
-                "ws_migrate",
-                "ws_makemigration",
-                "export_fixture",
-                "import_fixture",
-                "update-apps",
-            )
-        ) and not getattr(settings, "TEST_MIGRATION_RUNNING", False):
+        if _runtime_active():
             # dont need it if related model is of core
-            # try:
             cls._meta.apps.add_models(cls, self.related_model)
-            # except:
-            #     pass
             try:
                 self.related_model._meta.apps.add_models(self.related_model, cls)
             except Exception:
                 pass
-
-            apps = cls._meta.apps
-            apps.do_pending_operations(cls)
-            apps.do_pending_operations(self.related_model)
-            apps.clear_cache()
+            _defer_pending_operations(cls, self.related_model)
 
 
 # from django.db.models.utils import make_model_tuple
@@ -128,14 +167,8 @@ class ZManyToManyField(models.ManyToManyField):
     def contribute_to_class(self, cls, related):
         super().contribute_to_class(cls, related)
         if all(arg not in sys.argv for arg in ("ws_migrate", "ws_makemigration")):
-            apps = cls._meta.apps
-
             model_field = cls._meta.get_field(related)
             through_model = model_field.remote_field.through
             cls._meta.apps.add_models(cls, self.related_model)
             self.related_model._meta.apps.add_models(cls, self.related_model)
-
-            apps.do_pending_operations(self.model)
-            apps.do_pending_operations(self.related_model)
-            apps.do_pending_operations(through_model)
-            apps.clear_cache()
+            _defer_pending_operations(cls, self.related_model, through_model)


### PR DESCRIPTION
## The bug

Intermittent on worker restart — most visibly as `Internal Server Error: /app/login/` on workspaces with cross-file FKs (cadence and similar). The trace lands at:

\`\`\`
.../dynamic_models/fields/__init__.py:30, in contribute_to_class
    apps.do_pending_operations(cls)
.../django/apps/registry.py:411, in apply_next_model
.../django/db/models/fields/related.py:876, in contribute_to_related_class
    setattr(
\`\`\`

The `setattr` target is `cls._meta.concrete_model`, which is `None` at this moment. So the call is effectively `setattr(None, accessor_name, descriptor)` → `AttributeError`.

## Root cause

`ZForeignKey`, `ZOneToOneField`, and `ZManyToManyField` each called `apps.do_pending_operations(cls)` inside their `contribute_to_class`. That's during `ModelBase.__new__` — specifically during the field-contribute step, which runs **before** `Options._prepare(cls)` sets `concrete_model`:

\`\`\`
ModelBase.__new__
├── Options.contribute_to_class       (concrete_model still = None from __init__)
├── add_to_class for each field
│   └── ZForeignKey.contribute_to_class
│       └── apps.do_pending_operations(cls)    ← fires queued ops, setattr(None, ...) crashes
├── _prepare()
│   └── Options._prepare(cls)                  ← concrete_model = cls (too late)
└── apps.register_model(cls)
\`\`\`

The race fires whenever any earlier-defined model M has a string FK to `cls` (e.g. `ZForeignKey('masters.Brand', ...)` defined before `class Brand`). M's FK queued a pending operation for `cls`; the premature `do_pending_operations(cls)` pops and runs it before `cls` is safe.

### Why intermittent

The triggering condition is **import order**:

- `Workspace.get_models()` returns models via `bfs.reverse()` of the workspace tree — deterministic for a given workspace
- But the actual class-statement order depends on Python's recursive import resolution from whatever file `load_models()` reaches first, which depends on filesystem state, BFS tie-breaks, and (on threaded gunicorn) interleaved tenant boots
- Adding/removing a workspace file or shuffling cross-file imports can flip which class is defined first

So the same staging environment can crash on one restart and succeed on the next.

## The fix

Defer the `do_pending_operations` calls to a `class_prepared` receiver. Django emits `class_prepared` inside `Model._prepare()`, **after** `Options._prepare(cls)` has set `concrete_model`. By the time the receiver fires, `setattr(cls._meta.concrete_model, ...)` targets a real class object.

\`\`\`python
def _defer_pending_operations(cls, *related_models):
    def _resolve_pending(sender, **kwargs):
        try:
            apps = sender._meta.apps
            apps.do_pending_operations(sender)
            for related in related_models:
                if related is None:
                    continue
                try:
                    apps.do_pending_operations(related)
                except Exception:
                    pass
            apps.clear_cache()
        finally:
            class_prepared.disconnect(_resolve_pending, sender=sender)

    class_prepared.connect(_resolve_pending, sender=cls, weak=False)
\`\`\`

All three `Z*Field` classes now call this helper instead of `do_pending_operations` directly:

\`\`\`python
class ZForeignKey(models.ForeignKey):
    def contribute_to_class(self, cls, related):
        super().contribute_to_class(cls, related)
        if _runtime_active():
            cls._meta.apps.add_models(cls, self.related_model)
            try:
                self.related_model._meta.apps.add_models(self.related_model, cls)
            except Exception:
                pass
            _defer_pending_operations(cls, self.related_model)   # ← was apps.do_pending_operations(cls)
\`\`\`

Three notes on the receiver:

- **`sender=cls`** — the receiver only fires for this specific class, not for every model loaded process-wide.
- **`weak=False`** — `class_prepared.connect` defaults to a weak reference. The `_resolve_pending` closure has no other strong references after `contribute_to_class` returns; without `weak=False` Python would garbage-collect it before Django gets a chance to fire it.
- **Self-disconnect** — the receiver disconnects itself after firing so we don't accumulate dead handlers. Wrapped in `try/finally` so the disconnect runs even if a pending op raises.

## Timeline comparison

### Before (buggy)

\`\`\`
T70  class Brand(DynamicModelBase): ← starts
T72  Options.contribute_to_class    → concrete_model = None  ← THE WINDOW
T74  ZForeignKey.contribute_to_class
T77    apps.do_pending_operations(Brand)
         └ pops Territory's queued op
         └ setattr(None, "territory_set", descriptor)   🟥 AttributeError
\`\`\`

### After (fixed)

\`\`\`
T70  class Brand(DynamicModelBase): ← starts
T72  Options.contribute_to_class    → concrete_model = None
T74  ZForeignKey.contribute_to_class
T77    class_prepared.connect(_resolve_pending, sender=Brand, weak=False)
T79  Brand._prepare()
T80    Options._prepare(Brand)      → concrete_model = Brand   ← WINDOW CLOSES
T81    class_prepared.send(sender=Brand)
T82      _resolve_pending fires:
            apps.do_pending_operations(Brand)
              └ setattr(Brand, "territory_set", descriptor)   ✓
T84  apps.register_model(Brand)
       └ do_pending_operations(Brand) → empty list → no-op
\`\`\`

## Why this is robust to any import order

The buggy version's correctness depended on **no earlier model having a string FK to `cls`** at the moment `cls.__new__` runs. That's an unstable invariant — one new workspace model with a string FK can break it.

The fixed version's correctness depends on Django emitting `class_prepared` after `Options._prepare` sets `concrete_model`. That's a Django-stable contract.

So:

- Brand can be defined before, after, or alongside any number of models with FKs to Brand → still works
- Workspaces can use string FKs freely → still works
- Multi-tenant tenants can bootstrap in any order or interleaved → still works
- Future workspace authors don't need to know about this bug class → still works

## Test plan

- [x] Local smoke: `Workspace.ready()` succeeds on `newmi` tenant (18 models load cleanly)
- [ ] Staging: deploy to cadence, restart worker 30+ times, count failures. Establish a baseline first (current main) to confirm the bug reproduces, then deploy this PR and verify 0 failures.
- [ ] Workspaces with known cross-file string FKs (cadence's `masters/models.py`, similar patterns elsewhere): confirm `Workspace.ready()` succeeds without the `RepProfile.add_to_class` workaround being load-bearing — the workaround can stay but is no longer required.
- [ ] M2M relations: existing m2m_changed signal behavior unchanged (helper is invoked from `ZManyToManyField.contribute_to_class` with `through_model` passed in).

## Files touched

`backend/src/zango/apps/dynamic_models/fields/__init__.py` (+73 / -40)

## Not in scope

- The `RepProfile.add_to_class("manager", ...)` workaround in cadence's workspace stays as-is. After this fix it's no longer required, but removing it is a workspace-side cleanup unrelated to the framework change.
- Discovery of workspace string FKs that triggered the bug specifically on cadence is also workspace-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)