### PR TITLE
prepare release 1.2.0b5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0b5] - 2026-06-18
+
+### Fixed
+
+* Fix celery task import for AI tool usage update [(#594)](https://github.com/Healthlane-Technologies/Zango/pull/594)
+
 ## [1.2.0b4] - 2026-06-09
 
 ### Fixed

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -7,7 +7,7 @@ PROJECT_DIR = os.path.dirname(__file__)
 REQUIREMENTS_DIR = os.path.join(PROJECT_DIR, "requirements")
 README = os.path.join(PROJECT_DIR, "README.md")
 
-PLATFORM_VERSION = "1.2.0b4"
+PLATFORM_VERSION = "1.2.0b5"
 
 
 def get_requirements(env):

--- a/backend/src/zango/__init__.py
+++ b/backend/src/zango/__init__.py
@@ -2,4 +2,4 @@ from zango.core import internal_requests
 
 
 __all__ = ["internal_requests"]
-__version__ = "1.2.0b4"
+__version__ = "1.2.0b5"


### PR DESCRIPTION
## Summary

* Bump version to `1.2.0b5` in `backend/setup.py` and `backend/src/zango/__init__.py`
* Add `1.2.0b5` changelog entry covering the celery task import fix (#594)

## Changes

* Fix celery task import for AI tool usage update [(#594)](https://github.com/Healthlane-Technologies/Zango/pull/594)


🤖 Generated with [Claude Code](https://claude.com/claude-code)