### PR TITLE
fix(code_execution): dispatch celery task after transaction commits

### DIFF
--- a/backend/src/zango/api/platform/code_execution/v1/views.py
+++ b/backend/src/zango/api/platform/code_execution/v1/views.py
@@ -392,19 +392,34 @@ class CodeSnippetRunView(ZangoGenericPlatformAPIView, TenantMixin):
                         sha256=snip_file.sha256,
                     )
 
-            # Enqueue. The celery task does its own AST recheck on pickup.
-            try:
-                async_result = codexec_executor.apply_async(
-                    args=[str(execution.object_uuid), tenant.name],
-                    soft_time_limit=snippet.timeout_seconds,
-                    time_limit=snippet.timeout_seconds + 10,
-                )
-                execution.celery_task_id = (async_result.id or "")[:64]
-                execution.save(update_fields=["celery_task_id", "modified_at"])
-            except Exception:  # noqa: BLE001
-                # Couldn't reach the broker — mark queued anyway so the row is
-                # visible; user can re-enqueue. Don't 500 the whole request.
-                log.exception("codexec: failed to enqueue celery task")
+            # Enqueue AFTER the outer transaction commits. Django's
+            # ATOMIC_REQUESTS wraps every view in a transaction; the inner
+            # `transaction.atomic()` above is just a savepoint inside it.
+            # Without on_commit, codexec_executor.apply_async can land the
+            # task in the broker before the outer txn commits, and the
+            # worker — which polls the broker in milliseconds — will then
+            # SELECT for `object_uuid` against a snapshot that doesn't yet
+            # include the new CodeExecution row. The task body raises
+            # "codexec: execution <uuid> not found" and the run is lost.
+            # Deferring dispatch via on_commit guarantees the row is
+            # visible to every connection by the time the task is enqueued.
+            def _dispatch():
+                try:
+                    async_result = codexec_executor.apply_async(
+                        args=[str(execution.object_uuid), tenant.name],
+                        soft_time_limit=snippet.timeout_seconds,
+                        time_limit=snippet.timeout_seconds + 10,
+                    )
+                    execution.celery_task_id = (async_result.id or "")[:64]
+                    execution.save(
+                        update_fields=["celery_task_id", "modified_at"]
+                    )
+                except Exception:  # noqa: BLE001
+                    # Couldn't reach the broker — the execution row is
+                    # already committed, user can re-enqueue from the UI.
+                    log.exception("codexec: failed to enqueue celery task")
+
+            transaction.on_commit(_dispatch)
 
             return get_api_response(
                 True,


### PR DESCRIPTION
## Symptom

Intermittent Sentry events from \`zango.code_execution.codexec_executor\`:

> codexec: execution 774cc27a-ba06-403e-bc32-79f5893e8c29 not found

6 events / 1 day on staging. Tenant: \`newmicares\`. The breadcrumbs show the worker setting \`search_path = 'newmicares','public'\` and then a SELECT against \`code_execution_run\` joined with \`code_execution_snippet\` filtering by \`object_uuid\` — returns empty, task raises "not found."

## Root cause

Django's \`ATOMIC_REQUESTS = True\` (settings/base.py:417) wraps every view in an outer transaction. The dispatch flow:

\`\`\`
View enters
  → Django opens outer transaction (ATOMIC_REQUESTS)

  with transaction.atomic():              ← savepoint inside outer txn
      CodeExecution.objects.create(...)   ← INSERT, txn-visible only
      (snapshot files)
  exit savepoint                          ← released, outer txn STILL open

  codexec_executor.apply_async(...)       ← task enqueued NOW
  → row not yet visible to other connections

(celery worker polls within ms)
  → SET search_path = 'newmicares','public'
  → SELECT ... WHERE object_uuid = %s
  → empty result
  🟥 "codexec: execution <uuid> not found"

View returns
  → outer txn COMMITS (too late — worker already failed)
\`\`\`

The inner \`transaction.atomic()\` block is a savepoint, not a real commit. The actual COMMIT happens when the view returns successfully.

Staging hits this more than production because lower request volume → tighter transaction commit timing → larger window for the broker round-trip to win the race.

## Fix

Wrap the \`apply_async\` + \`celery_task_id\` save in a closure handed to \`transaction.on_commit\`:

\`\`\`python
def _dispatch():
    try:
        async_result = codexec_executor.apply_async(
            args=[str(execution.object_uuid), tenant.name],
            soft_time_limit=snippet.timeout_seconds,
            time_limit=snippet.timeout_seconds + 10,
        )
        execution.celery_task_id = (async_result.id or "")[:64]
        execution.save(update_fields=["celery_task_id", "modified_at"])
    except Exception:  # noqa: BLE001
        log.exception("codexec: failed to enqueue celery task")

transaction.on_commit(_dispatch)
\`\`\`

What \`on_commit\` does:
- Registers the callback against the outermost open transaction
- Fires synchronously after that transaction commits successfully
- If the transaction rolls back, callback never fires (correct: no row → no task)

By the time the task is enqueued, the row is visible to every connection.

The broker-failure \`try/except\` is preserved inside the closure so a dead broker still logs and continues without 500'ing the request.

## Test plan

- [ ] On staging: trigger codexec runs repeatedly under load, confirm \`codexec: execution <uuid> not found\` rate drops to 0
- [ ] On staging: kill the celery worker, trigger a run, verify the row exists in DB and the \`log.exception\` fires (broker-failure path still works)
- [ ] On staging: trigger a run, then immediately raise an exception mid-view (or roll back the outer txn somehow), verify the celery task is NOT dispatched (rollback path)

## Files touched

\`backend/src/zango/api/platform/code_execution/v1/views.py\` (+28 / -13)

## Other callsites worth auditing (out of scope)

The pattern "create row → dispatch task inside ATOMIC_REQUESTS view" probably exists elsewhere in Zango (AppUser creation → welcome email, file upload → processing, etc.). They may already use \`on_commit\` or be safe by other means. Flagging for awareness but not fixing in this PR — different code paths, different failure modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)