### PR TITLE
fix(code_execution): dispatch task after txn commit + alias workspace imports

### DIFF
--- a/backend/src/zango/api/platform/code_execution/v1/views.py
+++ b/backend/src/zango/api/platform/code_execution/v1/views.py
@@ -392,19 +392,34 @@ class CodeSnippetRunView(ZangoGenericPlatformAPIView, TenantMixin):
                         sha256=snip_file.sha256,
                     )
 
-            # Enqueue. The celery task does its own AST recheck on pickup.
-            try:
-                async_result = codexec_executor.apply_async(
-                    args=[str(execution.object_uuid), tenant.name],
-                    soft_time_limit=snippet.timeout_seconds,
-                    time_limit=snippet.timeout_seconds + 10,
-                )
-                execution.celery_task_id = (async_result.id or "")[:64]
-                execution.save(update_fields=["celery_task_id", "modified_at"])
-            except Exception:  # noqa: BLE001
-                # Couldn't reach the broker — mark queued anyway so the row is
-                # visible; user can re-enqueue. Don't 500 the whole request.
-                log.exception("codexec: failed to enqueue celery task")
+            # Enqueue AFTER the outer transaction commits. Django's
+            # ATOMIC_REQUESTS wraps every view in a transaction; the inner
+            # `transaction.atomic()` above is just a savepoint inside it.
+            # Without on_commit, codexec_executor.apply_async can land the
+            # task in the broker before the outer txn commits, and the
+            # worker — which polls the broker in milliseconds — will then
+            # SELECT for `object_uuid` against a snapshot that doesn't yet
+            # include the new CodeExecution row. The task body raises
+            # "codexec: execution <uuid> not found" and the run is lost.
+            # Deferring dispatch via on_commit guarantees the row is
+            # visible to every connection by the time the task is enqueued.
+            def _dispatch():
+                try:
+                    async_result = codexec_executor.apply_async(
+                        args=[str(execution.object_uuid), tenant.name],
+                        soft_time_limit=snippet.timeout_seconds,
+                        time_limit=snippet.timeout_seconds + 10,
+                    )
+                    execution.celery_task_id = (async_result.id or "")[:64]
+                    execution.save(
+                        update_fields=["celery_task_id", "modified_at"]
+                    )
+                except Exception:  # noqa: BLE001
+                    # Couldn't reach the broker — the execution row is
+                    # already committed, user can re-enqueue from the UI.
+                    log.exception("codexec: failed to enqueue celery task")
+
+            transaction.on_commit(_dispatch)
 
             return get_api_response(
                 True,

--- a/backend/src/zango/apps/code_execution/tasks.py
+++ b/backend/src/zango/apps/code_execution/tasks.py
@@ -286,6 +286,56 @@ def _serialize_return(value: Any) -> tuple[Optional[Any], bool, str]:
     return json.loads(payload), False, ""
 
 
+def _alias_workspace_models_in_sys_modules(workspace) -> None:
+    """Make `from workspaces.<tenant>.<path>.models import X` inside a
+    codexec snippet return the SAME class object that pluginbase loaded
+    during `Workspace.ready()`.
+
+    Background:
+    Workspace models are loaded twice in the same Python process under
+    different namespaces — pluginbase's private internal_space (which is
+    where Django, signals, and FKs get registered) and Python's regular
+    import machinery (which a snippet's `from workspaces…import X`
+    triggers). Same source file, two distinct class objects in memory.
+
+    The mismatch surfaces whenever Django does an instance-type check
+    against an FK target — most commonly during cascade collection on
+    `.delete()`, where the user's direct-import instance is rejected
+    because it's not an instance of the pluginbase class the FK was
+    registered against:
+
+        ValueError: Cannot query "WorkflowTransaction object (12555)":
+                    Must be "WorkflowTransaction" instance.
+
+    Fix: pre-populate sys.modules with the pluginbase-loaded module
+    object under the direct-import path. Python's import machinery
+    checks sys.modules before walking the filesystem, so the snippet's
+    `from workspaces.<tenant>.<path>.models import X` short-circuits to
+    the pluginbase module — and X is the registered class object.
+
+    This only aliases modules that `workspace.get_models()` returns
+    (i.e. workspace-defined models.py files). Non-model modules continue
+    to load normally and aren't affected.
+    """
+    for module_path in workspace.get_models():
+        # module_path looks like 'workspaces.<tenant>.<package_or_module>.models'
+        split = module_path.split(".")
+        if len(split) < 3 or split[0] != "workspaces":
+            continue
+        # Pluginbase relative path drops the 'workspaces.<tenant>.' prefix
+        # to match what Workspace.load_models() passes to load_plugin().
+        plugin_relative = ".".join(split[2:])
+        try:
+            pb_module = workspace.plugin_source.load_plugin(plugin_relative)
+        except Exception:  # noqa: BLE001
+            log.debug(
+                "codexec: could not load %s via pluginbase for sys.modules alias",
+                plugin_relative,
+            )
+            continue
+        sys.modules[module_path] = pb_module
+
+
 # ---------------------------------------------------------------------------
 # Celery task
 # ---------------------------------------------------------------------------
@@ -334,6 +384,13 @@ def codexec_executor(self, execution_uuid: str, tenant_name: str) -> dict:
             traceback.format_exc(),
             started_perf,
         )
+
+    # 3b. Make `from workspaces.<tenant>…import X` in the snippet resolve
+    #     to the pluginbase-loaded class objects (the ones Django + signals
+    #     + FKs are registered against). Without this, snippets that take
+    #     the direct-import path hit class-identity mismatches on `.delete()`
+    #     cascades and instance-based FK queries. See helper docstring.
+    _alias_workspace_models_in_sys_modules(ws)
 
     # 4. AST recheck (L1) — catches deny-list updates between save and pickup
     violations = validate(execution.source_snapshot)


### PR DESCRIPTION
Two related codexec fixes, bundled into one PR. Both surfaced from real Sentry events on staging this past week.

## Fix #1 — \`transaction.on_commit\` for codexec dispatch

### Symptom

Intermittent Sentry events from \`zango.code_execution.codexec_executor\`:

> codexec: execution 774cc27a-ba06-403e-bc32-79f5893e8c29 not found

### Root cause

Django's \`ATOMIC_REQUESTS = True\` wraps every view in an outer transaction. The dispatch flow:

\`\`\`
View enters → Django opens outer transaction (ATOMIC_REQUESTS)

  with transaction.atomic():              ← savepoint inside outer txn
      CodeExecution.objects.create(...)
  exit savepoint                          ← released, outer txn STILL open

  codexec_executor.apply_async(...)       ← task enqueued NOW
  → row not yet visible to other connections

(celery worker polls within ms)
  → SELECT … WHERE object_uuid = %s → empty result → "not found"

View returns → outer txn COMMITS (too late)
\`\`\`

### Fix

Wrap the dispatch in a closure handed to \`transaction.on_commit\`. The callback fires synchronously after the outer transaction commits, so the row is visible to every connection by the time the task is enqueued. If the transaction rolls back, the callback never fires — correct, no row → no task.

The broker-failure \`try/except\` is preserved inside the closure.

**File touched:** \`backend/src/zango/api/platform/code_execution/v1/views.py\` (+28 / -13)

---

## Fix #2 — Alias pluginbase-loaded workspace modules in \`sys.modules\`

### Symptom

Codexec snippets that use direct workspace imports — \`from workspaces.<tenant>.<path>.models import X\` — fail on operations where Django type-checks an instance against an FK target class. Most visibly on \`.delete()\`:

\`\`\`
ValueError: Cannot query "WorkflowTransaction object (12555)":
            Must be "WorkflowTransaction" instance.
\`\`\`

### Root cause

Workspace models are loaded twice in the same Python process under different namespaces:

| Loader | Where the class object lives | What references it |
|---|---|---|
| **Pluginbase** (via \`Workspace.ready() → load_models()\`) | \`pluginbase._internalspace._sp<hash>.<path>.models\` | Django's apps registry, FK target references, signal receivers |
| **Direct import** (\`from workspaces…import X\`) | \`workspaces.<tenant>.<path>.models\` | The snippet's local namespace |

Same source file, two distinct class objects. Reads via scalar filters work — no instance check involved. But \`.delete()\` triggers Django's deletion collector, which walks every reverse FK and passes the parent instance to a query like \`RelatedModel.objects.filter(transaction=workflow_transaction_instance)\`. The instance is of the direct-import class; the FK's \`related_model\` is the pluginbase class; \`isinstance\` returns False; ValueError.

### Fix

After \`Workspace.ready()\` populates pluginbase's namespace, walk \`workspace.get_models()\` and alias each pluginbase-loaded module into \`sys.modules\` under the direct-import path key. Python's import machinery checks \`sys.modules\` before walking the filesystem, so the snippet's \`from workspaces…import X\` short-circuits to the pluginbase module — and X is the same class object Django + FKs are registered against.

### What this enables

| Operation | Before | After |
|---|---|---|
| \`X.objects.filter(field=scalar)\` | ✓ works | ✓ works |
| \`X.objects.get(...)\` | ✓ works | ✓ works |
| \`X.objects.values_list(...)\` | ✓ works | ✓ works |
| \`X.objects.filter(fk=instance)\` | ✗ ValueError | ✓ works |
| \`Y.objects.create(x_fk=instance)\` | ✗ ValueError | ✓ works |
| \`queryset.delete()\` (with cascades) | ✗ ValueError | ✓ works |
| \`instance.related_set.add(other)\` | ✗ ValueError | ✓ works |
| Audit log on snippet-side save | ✗ silently skipped | ✓ logs |

The audit-log row is a real side benefit — \`auditlog.register\` connects signals to the pluginbase class object; the direct-import variant has no signals attached. With the alias, the snippet's X is the registered class, so \`X(...).save()\` fires the audit handler normally.

**File touched:** \`backend/src/zango/apps/code_execution/tasks.py\` (+57 / -0)

---

## Why these are bundled

Both fixes live in the codexec subsystem and address bugs that surfaced from the same staging environment in the same week. They touch different files (one in the API view that dispatches the task, one in the celery task that executes the snippet) and have no interaction — but they're naturally reviewed together.

## Test plan

### Fix #1 (on_commit)
- [ ] On staging: trigger codexec runs repeatedly under load, confirm \`codexec: execution <uuid> not found\` rate drops to 0
- [ ] On staging: kill the celery worker, trigger a run, verify the row exists in DB and \`log.exception\` fires (broker-failure path still works)
- [ ] On staging: raise an exception mid-view, verify the task is NOT dispatched (rollback path correct)

### Fix #2 (sys.modules alias)
- [ ] Run a snippet that does \`.delete()\` on a workspace queryset with FK cascades — confirm \`ValueError: Cannot query …\` no longer fires
- [ ] Run a snippet that does \`Y.objects.create(fk_field=instance)\` where instance came from a direct import — confirm no \`ValueError\`
- [ ] Run a snippet that saves a workspace model and verify a \`LogEntry\` row is written (audit log side benefit)
- [ ] Pre-existing scalar-filter snippets still behave identically (no regression)

## Files touched

- \`backend/src/zango/api/platform/code_execution/v1/views.py\` (+28 / -13)
- \`backend/src/zango/apps/code_execution/tasks.py\` (+57 / -0)

## Out of scope

The pattern "create row → dispatch task inside ATOMIC_REQUESTS view" probably exists elsewhere in Zango (AppUser creation → welcome email, file upload → processing, etc.). They may already use \`on_commit\` or be safe by other means. Flagging for awareness but not fixing here — different code paths, different failure modes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)