### PR TITLE
feat: app- and role-level auth token TTL configuration

### DIFF
--- a/backend/src/zango/api/platform/tenancy/v1/serializers.py
+++ b/backend/src/zango/api/platform/tenancy/v1/serializers.py
@@ -12,6 +12,50 @@ from zango.apps.shared.tenancy.schema import AuthConfigSchema as TenantAuthConfi
 from zango.core.utils import get_auth_priority, get_datetime_str_in_tenant_timezone
 
 
+# Upper bound for a configurable token TTL: 1 year in seconds. Guards against an
+# accidental huge value being mistaken for the explicit 0 ("never expires") sentinel.
+MAX_TOKEN_TTL_SECONDS = 31536000
+
+
+def get_platform_token_ttl_seconds():
+    """Platform-wide default token TTL in seconds (0 means "never expires").
+
+    Derived from the Knox setting so it matches the actual fallback used when an
+    app/role does not configure its own ``token_ttl``.
+    """
+    from knox.settings import knox_settings
+
+    ttl = knox_settings.TOKEN_TTL
+    return 0 if ttl is None else int(ttl.total_seconds())
+
+
+def validate_session_policy_token_ttl(auth_config):
+    """Validate ``session_policy.token_ttl`` if present in an auth_config dict.
+
+    ``token_ttl`` is seconds (int). ``0`` means "never expires". Absence means
+    "inherit" and is always valid. Raises ``serializers.ValidationError`` otherwise.
+    """
+    session_policy = (auth_config or {}).get("session_policy")
+    if not session_policy or "token_ttl" not in session_policy:
+        return
+    ttl = session_policy["token_ttl"]
+    # bool is a subclass of int -- reject it explicitly.
+    if isinstance(ttl, bool) or not isinstance(ttl, int):
+        raise serializers.ValidationError(
+            "session_policy.token_ttl must be an integer number of seconds "
+            "(0 means the token never expires)."
+        )
+    if ttl < 0:
+        raise serializers.ValidationError(
+            "session_policy.token_ttl cannot be negative."
+        )
+    if ttl > MAX_TOKEN_TTL_SECONDS:
+        raise serializers.ValidationError(
+            f"session_policy.token_ttl cannot exceed {MAX_TOKEN_TTL_SECONDS} "
+            "seconds (1 year). Use 0 for a token that never expires."
+        )
+
+
 class DomainSerializerModel(serializers.ModelSerializer):
     class Meta:
         model = Domain
@@ -76,7 +120,23 @@ class TenantSerializerModel(serializers.ModelSerializer):
     def get_date_format_display(self, obj):
         return obj.get_date_format_display()
 
+    def to_representation(self, instance):
+        data = super().to_representation(instance)
+        # Surface the platform-wide default token TTL alongside the app's
+        # auth_config so the UI can show the effective value when an app/role
+        # inherits ("Platform default"). Read-only, ignored on write.
+        auth_config = data.get("auth_config")
+        if isinstance(auth_config, dict):
+            session_policy = dict(auth_config.get("session_policy") or {})
+            session_policy["platform_token_ttl"] = get_platform_token_ttl_seconds()
+            auth_config["session_policy"] = session_policy
+        return data
+
     def validate_auth_config(self, value: TenantAuthConfigSchema):
+        # platform_token_ttl is a read-only, server-computed hint; never persist it.
+        if isinstance(value, dict) and isinstance(value.get("session_policy"), dict):
+            value["session_policy"].pop("platform_token_ttl", None)
+        validate_session_policy_token_ttl(value)
         return value
 
     def update(self, instance, validated_data):
@@ -185,6 +245,8 @@ class UserRoleSerializerModel(serializers.ModelSerializer):
         return data
 
     def validate_auth_config(self, value: UserRoleAuthConfig):
+        validate_session_policy_token_ttl(value)
+
         tenant = self.context.get("tenant")
         if not tenant:
             return value

--- a/backend/src/zango/apps/appauth/models.py
+++ b/backend/src/zango/apps/appauth/models.py
@@ -18,7 +18,7 @@ from zango.apps.shared.platformauth.abstract_model import (
     AbstractZangoUserModel,
 )
 from zango.core.model_mixins import FullAuditMixin
-from zango.core.utils import get_auth_priority
+from zango.core.utils import get_app_token_ttl, get_auth_priority
 
 from ..permissions.mixin import PermissionMixin
 
@@ -72,11 +72,32 @@ class AppUserModel(
     app_objects = models.JSONField(null=True)
     auth_config = models.JSONField(default=get_default_app_user_auth_config)
 
-    def generate_auth_token(self, role, expiry=knox_settings.TOKEN_TTL):
+    def generate_auth_token(self, role, expiry=None):
         try:
             AppUserAuthToken.objects.filter(user=self).delete()
         except Exception:
             pass
+
+        # Resolve role to a model instance first so its auth_config is available
+        # when resolving the token TTL below.
+        if isinstance(role, UserRoleModel):
+            pass
+        elif isinstance(role, int):
+            role = UserRoleModel.objects.get(id=role)
+        elif isinstance(role, str):
+            if role.isdigit():
+                role = UserRoleModel.objects.get(id=int(role))
+            else:
+                role = UserRoleModel.objects.get(name=role)
+        else:
+            raise Exception("Specify Role ID or Role name")
+
+        # When no explicit expiry is passed, resolve it via the auth precedence
+        # (user_role > tenant > platform default). The helper returns a timedelta
+        # or None ("no expiry") -- never a raw 0 -- so the int branch below is
+        # only hit for explicit integer-seconds callers.
+        if expiry is None:
+            expiry = get_app_token_ttl(user=self, user_role=role)
 
         if isinstance(expiry, int):
             expiry = timedelta(seconds=expiry)
@@ -86,15 +107,6 @@ class AppUserModel(
             expiry=expiry,
             prefix=knox_settings.TOKEN_PREFIX,
         )
-        if isinstance(role, int):
-            role = UserRoleModel.objects.get(id=role)
-        elif isinstance(role, str):
-            if role.isdigit():
-                role = UserRoleModel.objects.get(id=int(role))
-            else:
-                role = UserRoleModel.objects.get(name=role)
-        else:
-            raise Exception("Specify Role ID or Role name")
         inst.role = role
         inst.save()
         return (inst, token)

--- a/backend/src/zango/apps/appauth/schema.py
+++ b/backend/src/zango/apps/appauth/schema.py
@@ -6,7 +6,7 @@ try:
 except ImportError:
     from typing_extensions import Required
 
-from zango.apps.shared.tenancy.schema import PasswordPolicy
+from zango.apps.shared.tenancy.schema import PasswordPolicy, SessionPolicy
 
 
 class TwoFactorAuth(TypedDict, total=False):
@@ -18,6 +18,7 @@ class UserRoleAuthConfig(TypedDict, total=False):
     password_policy: PasswordPolicy
     two_factor_auth: TwoFactorAuth
     enforce_sso: bool
+    session_policy: SessionPolicy  # only token_ttl is meaningful at role level
 
 
 class SSOIdentity(TypedDict):

--- a/backend/src/zango/apps/shared/tenancy/schema.py
+++ b/backend/src/zango/apps/shared/tenancy/schema.py
@@ -97,8 +97,9 @@ class TwoFactorAuth(TypedDict, total=False):
     sms_hook: str
 
 
-class SessionPolicy(TypedDict):
+class SessionPolicy(TypedDict, total=False):
     max_concurrent_sessions: int
+    token_ttl: int  # seconds; 0 = no expiry; absent = inherit platform default
 
 
 class AuthConfigSchema(TypedDict, total=False):

--- a/backend/src/zango/core/utils.py
+++ b/backend/src/zango/core/utils.py
@@ -496,6 +496,32 @@ def get_auth_priority(
         return ""
 
 
+def get_app_token_ttl(user=None, user_role=None, tenant=None):
+    """Resolve the auth token TTL using the standard auth precedence
+    (user_role > tenant > platform default).
+
+    Returns a ``timedelta``, or ``None`` for "no expiry".
+
+    Note: ``token_ttl == 0`` is the Zango convention for "never expires" and is
+    translated to ``None`` here, before the value reaches Knox. Knox only treats
+    ``None`` as never-expires; a ``timedelta(0)`` would expire the token immediately.
+    """
+    from datetime import timedelta
+
+    from knox.settings import knox_settings
+
+    session_policy = get_auth_priority(
+        policy="session_policy",
+        user=user,
+        user_role=user_role,
+        tenant=tenant,
+    )
+    ttl = (session_policy or {}).get("token_ttl")
+    if ttl is None:
+        return knox_settings.TOKEN_TTL  # platform default (timedelta or None)
+    return None if ttl == 0 else timedelta(seconds=ttl)
+
+
 def mask_email(email):
     """Masks an email address, showing only the first and last character before the '@' and the domain."""
     if "@" not in email:

--- a/frontend/src/pages/appConfiguration/components/AppConfiguration/AuthConfiguration/AuthSetupModal.jsx
+++ b/frontend/src/pages/appConfiguration/components/AppConfiguration/AuthConfiguration/AuthSetupModal.jsx
@@ -1,6 +1,8 @@
 import React, { useState, useMemo, useEffect } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { Fragment } from 'react';
+import { humanizeTokenTtl } from '../../../../../utils/tokenTtl';
+import TokenTtlField from './TokenTtlField';
 
 // JSON Key-Value Pair Input Component (moved outside to prevent recreation on every render)
 const JsonKeyValueInput = React.memo(({ value, onChange, placeholder = "Add key-value pairs" }) => {
@@ -134,7 +136,7 @@ const JsonKeyValueInput = React.memo(({ value, onChange, placeholder = "Add key-
 
 const AuthSetupModal = ({ show, onClose, onComplete, initialData = null, roles = [] }) => {
 	const [currentStep, setCurrentStep] = useState(1);
-	const totalSteps = 4;
+	const totalSteps = 5;
 
 	// Default setup data
 	const defaultSetupData = {
@@ -286,7 +288,7 @@ const AuthSetupModal = ({ show, onClose, onComplete, initialData = null, roles =
 	// Step components
 	const StepIndicator = () => (
 		<div className="flex items-center justify-center mb-[32px]">
-			{[1, 2, 3, 4].map((step) => (
+			{[1, 2, 3, 4, 5].map((step) => (
 				<div key={step} className="flex items-center">
 					<div
 						className={`w-[40px] h-[40px] rounded-full flex items-center justify-center font-medium text-[14px] transition-all ${
@@ -305,7 +307,7 @@ const AuthSetupModal = ({ show, onClose, onComplete, initialData = null, roles =
 							step
 						)}
 					</div>
-					{step < 4 && (
+					{step < 5 && (
 						<div className={`w-[60px] h-[2px] mx-[8px] transition-all ${
 							step < currentStep ? 'bg-[#10B981]' : 'bg-[#E5E7EB]'
 						}`} />
@@ -1264,8 +1266,38 @@ const AuthSetupModal = ({ show, onClose, onComplete, initialData = null, roles =
 		</div>
 	), [setupData.two_factor_auth]);
 
-	// Step 4: Review
-	const Step4Review = useMemo(() => (
+	// Step 4: Session & Tokens
+	const Step4SessionTokens = useMemo(() => (
+		<div className="space-y-[24px]">
+			<div>
+				<h3 className="text-[20px] font-semibold text-[#111827] mb-[4px]">Session &amp; Tokens</h3>
+				<p className="text-[14px] text-[#6B7280]">Configure session and token settings for this app</p>
+			</div>
+
+			<div className="bg-[#F8FAFC] rounded-[12px] p-[20px]">
+				<label className="block text-[14px] font-medium text-[#111827] mb-[8px]">
+					Token expiry
+				</label>
+				<TokenTtlField
+					value={setupData.session_policy.token_ttl}
+					inheritedValue={setupData.session_policy.platform_token_ttl}
+					onChange={(next) => setSetupData(prev => ({
+						...prev,
+						session_policy: {
+							...prev.session_policy,
+							token_ttl: next
+						}
+					}))}
+				/>
+				<p className="mt-[8px] text-[12px] text-[#6B7280]">
+					Lifetime of API auth tokens issued on login. Choose <span className="font-medium">Platform default</span> to inherit the global setting.
+				</p>
+			</div>
+		</div>
+	), [setupData.session_policy.token_ttl]);
+
+	// Step 5: Review
+	const Step5Review = useMemo(() => (
 		<div className="space-y-[24px]">
 			<div>
 				<h3 className="text-[20px] font-semibold text-[#111827] mb-[4px]">Review Configuration</h3>
@@ -1354,6 +1386,7 @@ const AuthSetupModal = ({ show, onClose, onComplete, initialData = null, roles =
 					<div className="space-y-[8px] text-[14px] text-[#111827]">
 						<div>Maximum concurrent sessions: {setupData.session_policy.max_concurrent_sessions === 0 ? 'Unlimited' : setupData.session_policy.max_concurrent_sessions}</div>
 						<div>Force logout on password change: {setupData.session_policy.force_logout_on_password_change ? 'Yes' : 'No'}</div>
+						<div>Token expiry: {humanizeTokenTtl(setupData.session_policy.token_ttl)}</div>
 					</div>
 				</div>
 
@@ -1447,7 +1480,9 @@ const AuthSetupModal = ({ show, onClose, onComplete, initialData = null, roles =
 			case 3:
 				return Step3TwoFactor;
 			case 4:
-				return Step4Review;
+				return Step4SessionTokens;
+			case 5:
+				return Step5Review;
 			default:
 				return null;
 		}

--- a/frontend/src/pages/appConfiguration/components/AppConfiguration/AuthConfiguration/ModernAuthConfig.jsx
+++ b/frontend/src/pages/appConfiguration/components/AppConfiguration/AuthConfiguration/ModernAuthConfig.jsx
@@ -5,6 +5,7 @@ import * as Yup from 'yup';
 import { selectAppConfigurationData, toggleRerenderPage } from '../../../slice';
 import useApi from '../../../../../hooks/useApi';
 import { transformToFormData } from '../../../../../utils/form';
+import { humanizeTokenTtl, humanizeTokenTtlWithDefault } from '../../../../../utils/tokenTtl';
 import { useParams, useNavigate } from 'react-router-dom';
 import InputField from '../../../../../components/Form/InputField';
 import AuthSetupModal from './AuthSetupModal';
@@ -167,6 +168,7 @@ const ModernAuthConfig = () => {
 							},
 							session_policy: {
 								max_concurrent_sessions: authData.session_policy.max_concurrent_sessions,
+								token_ttl: authData.session_policy.token_ttl ?? '',
 							},
 							password_policy: {
 								min_length: authData.password_policy.min_length,
@@ -211,6 +213,13 @@ const ModernAuthConfig = () => {
 								sms_hook: authData.two_factor_auth.sms_hook || '',
 							},
 						};
+
+						// token_ttl: a blank value means "inherit the platform default",
+						// so drop the key rather than persisting an empty/0 value.
+						const tokenTtl = authConfig.session_policy.token_ttl;
+						if (tokenTtl === '' || tokenTtl === null || tokenTtl === undefined) {
+							delete authConfig.session_policy.token_ttl;
+						}
 
 						// Save the configuration
 						const tempValues = {
@@ -278,6 +287,11 @@ const ModernAuthConfig = () => {
 		}),
 		session_policy: Yup.object({
 			max_concurrent_sessions: Yup.number().min(0, "Cannot be negative"),
+			token_ttl: Yup.number()
+				.integer("Must be a whole number of seconds")
+				.min(0, "Cannot be negative")
+				.max(31536000, "Cannot exceed 31536000 seconds (1 year)")
+				.nullable(),
 		}),
 		password_policy: Yup.object({
 			min_length: Yup.number().min(4, "Minimum length must be at least 4").max(128, "Maximum length is 128"),
@@ -298,8 +312,18 @@ const ModernAuthConfig = () => {
 	// Handle form submission
 	const handleSubmit = async (values) => {
 		setIsSaving(true);
-		
+
 		const cleanedAuthConfig = values;
+
+		// token_ttl: a blank value means "inherit the platform default", so drop
+		// the key rather than persisting an empty/0 value (0 = never expires).
+		const tokenTtl = cleanedAuthConfig?.session_policy?.token_ttl;
+		if (tokenTtl === '' || tokenTtl === null || tokenTtl === undefined) {
+			if (cleanedAuthConfig?.session_policy) {
+				delete cleanedAuthConfig.session_policy.token_ttl;
+			}
+		}
+
 		const tempValues = {
 			auth_config: JSON.stringify(cleanedAuthConfig)
 		};
@@ -739,6 +763,17 @@ const ModernAuthConfig = () => {
 														onChange={(e) => setFieldValue("session_policy.max_concurrent_sessions", parseInt(e.target.value) || 0)}
 													/>
 												</div>
+												<div>
+													<InputField
+														name="session_policy.token_ttl"
+														label="Token expiry in seconds (0 = never expires)"
+														type="number"
+														placeholder="Inherit platform default"
+														value={values?.session_policy?.token_ttl ?? ''}
+														onChange={(e) => setFieldValue("session_policy.token_ttl", e.target.value === '' ? '' : parseInt(e.target.value))}
+													/>
+													<p className="text-[12px] text-[#6B7280] mt-[2px]">Lifetime of API auth tokens. Leave blank to inherit the platform default.</p>
+												</div>
 												<div className="flex items-center justify-between">
 													<div>
 														<p className="text-[14px] font-medium text-[#111827]">Force logout on password change</p>
@@ -884,6 +919,11 @@ const ModernAuthConfig = () => {
 									color="purple"
 								/>
 								<QuickStat
+									label="Token Expiry"
+									value={humanizeTokenTtlWithDefault(authConfig.session_policy?.token_ttl, authConfig.session_policy?.platform_token_ttl)}
+									color="blue"
+								/>
+								<QuickStat
 									label="Password Expiry"
 									value={`${authConfig.password_policy?.password_expiry_days || 90} days`}
 									color="amber"
@@ -1003,6 +1043,12 @@ const ModernAuthConfig = () => {
 													{authConfig.session_policy?.max_concurrent_sessions || 'Unlimited'}
 												</span>
 											</div>
+											<div className="flex items-center justify-between mb-[4px]">
+												<p className="text-[13px] font-medium text-[#111827]">Token Expiry</p>
+												<span className="px-[8px] py-[2px] bg-[#DBEAFE] text-[#1E40AF] rounded-[6px] text-[11px] font-medium">
+													{humanizeTokenTtlWithDefault(authConfig.session_policy?.token_ttl, authConfig.session_policy?.platform_token_ttl)}
+												</span>
+											</div>
 											<p className="text-[12px] text-[#6B7280]">
 												{authConfig.session_policy?.force_logout_on_password_change
 													? 'Force logout on password change'
@@ -1080,9 +1126,14 @@ const ModernAuthConfig = () => {
 															2FA Required
 														</span>
 													)}
-													{role.auth_config.session_policy && (
+													{role.auth_config.session_policy?.max_concurrent_sessions !== undefined && role.auth_config.session_policy?.max_concurrent_sessions !== null && (
 														<span className="px-[6px] py-[2px] bg-[#FEF3C7] text-[#92400E] rounded-[4px] text-[10px] font-medium">
-															Session
+															Max sessions: {role.auth_config.session_policy.max_concurrent_sessions || 'Unlimited'}
+														</span>
+													)}
+													{role.auth_config.session_policy?.token_ttl !== undefined && role.auth_config.session_policy?.token_ttl !== null && (
+														<span className="px-[6px] py-[2px] bg-[#DBEAFE] text-[#1E40AF] rounded-[4px] text-[10px] font-medium">
+															Token: {humanizeTokenTtl(role.auth_config.session_policy.token_ttl)}
 														</span>
 													)}
 												</div>
@@ -1197,8 +1248,16 @@ const ModernAuthConfig = () => {
 											</span>
 										</div>
 									</div>
-									<ConfigToggle 
-										label="Force logout on password change" 
+									<div>
+										<p className="text-[13px] text-[#6B7280] mb-[4px]">Token expiry</p>
+										<div className="flex items-center gap-[8px]">
+											<span className="text-[20px] font-semibold text-[#111827]">
+												{humanizeTokenTtlWithDefault(authConfig.session_policy?.token_ttl, authConfig.session_policy?.platform_token_ttl)}
+											</span>
+										</div>
+									</div>
+									<ConfigToggle
+										label="Force logout on password change"
 										enabled={authConfig.session_policy?.force_logout_on_password_change}
 										description="Terminate all sessions when password is changed"
 									/>
@@ -1547,6 +1606,7 @@ const ModernAuthConfig = () => {
 							},
 							session_policy: {
 								max_concurrent_sessions: authData.session_policy.max_concurrent_sessions,
+								token_ttl: authData.session_policy.token_ttl ?? '',
 							},
 							password_policy: {
 								min_length: authData.password_policy.min_length,
@@ -1591,6 +1651,13 @@ const ModernAuthConfig = () => {
 								sms_hook: authData.two_factor_auth.sms_hook || '',
 							},
 						};
+
+						// token_ttl: a blank value means "inherit the platform default",
+						// so drop the key rather than persisting an empty/0 value.
+						const tokenTtl = updatedAuthConfig.session_policy.token_ttl;
+						if (tokenTtl === '' || tokenTtl === null || tokenTtl === undefined) {
+							delete updatedAuthConfig.session_policy.token_ttl;
+						}
 
 						// Save the configuration
 						const tempValues = {

--- a/frontend/src/pages/appConfiguration/components/AppConfiguration/AuthConfiguration/RoleOverrideModal.jsx
+++ b/frontend/src/pages/appConfiguration/components/AppConfiguration/AuthConfiguration/RoleOverrideModal.jsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { Dialog, Transition } from '@headlessui/react';
 import { Fragment } from 'react';
+import TokenTtlField from './TokenTtlField';
 
 const RoleOverrideModal = ({ show, onClose, onSave, roles = [], globalAuthConfig = {}, currentOverrides = {}, initialSelectedRoleId = null }) => {
 	const [selectedRoleId, setSelectedRoleId] = useState(null);
@@ -79,7 +80,14 @@ const RoleOverrideModal = ({ show, onClose, onSave, roles = [], globalAuthConfig
 				cleanedOverride.two_factor_auth = overrideConfig.two_factor_auth;
 			}
 			if (overrideConfig.session_policy) {
-				cleanedOverride.session_policy = overrideConfig.session_policy;
+				const sessionPolicy = { ...overrideConfig.session_policy };
+				// A blank token_ttl means "inherit the app / platform default";
+				// drop the key rather than persisting an empty/0 value.
+				const tokenTtl = sessionPolicy.token_ttl;
+				if (tokenTtl === '' || tokenTtl === null || tokenTtl === undefined) {
+					delete sessionPolicy.token_ttl;
+				}
+				cleanedOverride.session_policy = sessionPolicy;
 			}
 			// Include enforce_sso
 			cleanedOverride.enforce_sso = overrideConfig.enforce_sso ?? false;
@@ -547,7 +555,7 @@ const RoleOverrideModal = ({ show, onClose, onSave, roles = [], globalAuthConfig
 														</div>
 
 													{enableSessionPolicyOverride && (
-														<div className="mt-[20px] bg-white rounded-[8px] p-[16px]">
+														<div className="mt-[20px] bg-white rounded-[8px] p-[16px] space-y-[16px]">
 															<div>
 																<label className="block text-[13px] font-medium text-[#111827] mb-[8px]">
 																	Maximum Concurrent Sessions (0 = unlimited)
@@ -565,6 +573,35 @@ const RoleOverrideModal = ({ show, onClose, onSave, roles = [], globalAuthConfig
 																	}))}
 																	className="w-full px-[12px] py-[8px] border border-[#E5E7EB] rounded-[8px] text-[14px] focus:outline-none focus:ring-2 focus:ring-[#5048ED] focus:border-transparent"
 																/>
+															</div>
+															<div>
+																<label className="block text-[13px] font-medium text-[#111827] mb-[8px]">
+																	Token Expiry
+																</label>
+																{(() => {
+																	// A role inherits the app-level token_ttl when the app
+																	// has set one; otherwise it inherits the platform default.
+																	const appTtl = globalAuthConfig?.session_policy?.token_ttl;
+																	const appHasOverride = appTtl !== undefined && appTtl !== null;
+																	return (
+																		<TokenTtlField
+																			key={selectedRoleId}
+																			value={overrideConfig.session_policy?.token_ttl}
+																			inheritedValue={appHasOverride ? appTtl : globalAuthConfig?.session_policy?.platform_token_ttl}
+																			inheritLabel={appHasOverride ? 'App default' : 'Platform default'}
+																			onChange={(next) => setOverrideConfig(prev => ({
+																				...prev,
+																				session_policy: {
+																					...prev.session_policy,
+																					token_ttl: next
+																				}
+																			}))}
+																		/>
+																	);
+																})()}
+																<p className="mt-[6px] text-[12px] text-[#6B7280]">
+																	Overrides the app-level token expiry for users logging in with this role. Choose <span className="font-medium">Platform default</span> to inherit.
+																</p>
 															</div>
 														</div>
 													)}

--- a/frontend/src/pages/appConfiguration/components/AppConfiguration/AuthConfiguration/TokenTtlField.jsx
+++ b/frontend/src/pages/appConfiguration/components/AppConfiguration/AuthConfiguration/TokenTtlField.jsx
@@ -1,0 +1,162 @@
+import { Fragment, useEffect, useRef, useState } from 'react';
+import { Listbox, Transition } from '@headlessui/react';
+import { TTL_UNITS, ttlToSeconds, splitTtlSeconds, ttlMode, humanizeTokenTtl } from '../../../../../utils/tokenTtl';
+
+const ChevronIcon = () => (
+	<svg width="16" height="16" viewBox="0 0 20 20" fill="none" className="text-[#6B7280] pointer-events-none">
+		<path d="M6 8L10 12L14 8" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+	</svg>
+);
+
+const CheckIcon = () => (
+	<svg width="16" height="16" viewBox="0 0 16 16" fill="none" className="text-[#5048ED]">
+		<path d="M13.5 4.5L6 12L2.5 8.5" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round" />
+	</svg>
+);
+
+// A modern Listbox-based dropdown matching the app's styling.
+function Dropdown({ value, options, onChange, className = '' }) {
+	const selected = options.find((o) => o.key === value) || options[0];
+	return (
+		<Listbox value={value} onChange={onChange}>
+			<div className={`relative ${className}`}>
+				<Listbox.Button className="flex w-full items-center justify-between gap-[8px] rounded-[8px] border border-[#E5E7EB] bg-white px-[12px] py-[8px] text-[14px] text-[#111827] transition-colors hover:border-[#D1D5DB] focus:outline-none focus:ring-2 focus:ring-[#5048ED] focus:border-transparent">
+					<span className="block truncate text-left">{selected.label}</span>
+					<ChevronIcon />
+				</Listbox.Button>
+				<Transition
+					as={Fragment}
+					leave="transition ease-in duration-100"
+					leaveFrom="opacity-100"
+					leaveTo="opacity-0"
+				>
+					<Listbox.Options className="absolute z-[60] mt-[4px] max-h-60 w-full min-w-[140px] overflow-auto rounded-[10px] border border-[#E5E7EB] bg-white py-[6px] shadow-lg focus:outline-none">
+						{options.map((option) => (
+							<Listbox.Option
+								key={option.key}
+								value={option.key}
+								className={({ active }) =>
+									`relative flex cursor-pointer select-none items-center justify-between px-[12px] py-[8px] text-[14px] ${
+										active ? 'bg-[#F5F4FF] text-[#5048ED]' : 'text-[#111827]'
+									}`
+								}
+							>
+								{({ selected: isSelected }) => (
+									<>
+										<span className={`block truncate ${isSelected ? 'font-medium' : 'font-normal'}`}>
+											{option.label}
+										</span>
+										{isSelected && <CheckIcon />}
+									</>
+								)}
+							</Listbox.Option>
+						))}
+					</Listbox.Options>
+				</Transition>
+			</div>
+		</Listbox>
+	);
+}
+
+// Controlled token TTL editor.
+// value: number of seconds, 0 ("never"), or '' / null / undefined ("inherit").
+// onChange(nextValue) receives the same shape.
+// inheritedValue: seconds (0 = never) of the value this level inherits when not
+//   overridden, shown on the inherit option so admins see the effective value.
+// inheritLabel: wording for the inherit option (e.g. "Platform default" or, for a
+//   role that inherits an app-level override, "App default").
+export default function TokenTtlField({
+	value,
+	onChange,
+	inheritedValue,
+	inheritLabel = 'Platform default',
+}) {
+	const [mode, setMode] = useState(() => ttlMode(value));
+	const [unit, setUnit] = useState(() => splitTtlSeconds(value).unit);
+	// Tracks the value this component last emitted, so the sync effect can tell a
+	// self-induced change (e.g. picking "custom" -> '') apart from an external
+	// reset (role switch / modal reopen) and only force-resync on the latter.
+	const lastEmitted = useRef(value);
+
+	const defaultLabel =
+		inheritedValue === undefined || inheritedValue === null
+			? inheritLabel
+			: `${inheritLabel} (${humanizeTokenTtl(inheritedValue)})`;
+
+	const modeOptions = [
+		{ key: 'default', label: defaultLabel },
+		{ key: 'never', label: 'Never expires' },
+		{ key: 'custom', label: 'Custom' },
+	];
+
+	// Emit a change upward and remember what we sent, so the sync effect can
+	// distinguish our own updates from external ones.
+	const emit = (next) => {
+		lastEmitted.current = next;
+		onChange(next);
+	};
+
+	// Re-sync local mode/unit only when the value changes from the OUTSIDE
+	// (role switch / modal reopen). Self-induced changes are ignored so that
+	// picking "custom" (which emits '') doesn't snap the dropdown back to
+	// "default" before the user types a number.
+	useEffect(() => {
+		if (value === lastEmitted.current) return;
+		lastEmitted.current = value;
+		setMode(ttlMode(value));
+		setUnit(splitTtlSeconds(value).unit);
+	}, [value]);
+
+	const handleModeChange = (nextMode) => {
+		setMode(nextMode);
+		if (nextMode === 'default') emit('');
+		else if (nextMode === 'never') emit(0);
+		else emit(''); // custom: wait for the user to type a number
+	};
+
+	const handleUnitChange = (nextUnit) => {
+		if (value !== '' && value !== null && value !== undefined && value !== 0) {
+			const oldU = TTL_UNITS.find((u) => u.key === unit) || TTL_UNITS[0];
+			const displayed = value / oldU.seconds;
+			emit(ttlToSeconds(displayed, nextUnit));
+		}
+		setUnit(nextUnit);
+	};
+
+	const numberValue = (() => {
+		if (mode !== 'custom' || value === '' || value === null || value === undefined) return '';
+		const u = TTL_UNITS.find((x) => x.key === unit) || TTL_UNITS[0];
+		return value / u.seconds;
+	})();
+
+	return (
+		<div className="flex flex-wrap items-start gap-[8px]">
+			<Dropdown
+				value={mode}
+				options={modeOptions}
+				onChange={handleModeChange}
+				className="w-[230px]"
+			/>
+			{mode === 'custom' && (
+				<>
+					<input
+						type="number"
+						min="1"
+						placeholder="e.g. 7"
+						value={numberValue}
+						onChange={(e) =>
+							emit(e.target.value === '' ? '' : ttlToSeconds(e.target.value, unit))
+						}
+						className="w-[110px] rounded-[8px] border border-[#E5E7EB] px-[12px] py-[8px] text-[14px] text-[#111827] focus:outline-none focus:ring-2 focus:ring-[#5048ED] focus:border-transparent"
+					/>
+					<Dropdown
+						value={unit}
+						options={TTL_UNITS.map((u) => ({ key: u.key, label: u.label }))}
+						onChange={handleUnitChange}
+						className="w-[130px]"
+					/>
+				</>
+			)}
+		</div>
+	);
+}

--- a/frontend/src/pages/appConfiguration/components/AuthConfigurationForm/index.jsx
+++ b/frontend/src/pages/appConfiguration/components/AuthConfigurationForm/index.jsx
@@ -45,6 +45,11 @@ const AuthConfigurationForm = () => {
 		session_policy: Yup.object({
 			max_concurrent_sessions: Yup.number().min(0, "Cannot be negative"),
 			force_logout_on_password_change: Yup.boolean(),
+			token_ttl: Yup.number()
+				.integer("Must be a whole number of seconds")
+				.min(0, "Cannot be negative")
+				.max(31536000, "Cannot exceed 31536000 seconds (1 year)")
+				.nullable(),
 		}),
 		password_policy: Yup.object({
 			min_length: Yup.number().min(4, "Minimum length must be at least 4").max(128, "Maximum length is 128"),
@@ -64,7 +69,17 @@ const AuthConfigurationForm = () => {
 
 	let onSubmit = (values) => {
 		const cleanedAuthConfig = values;
-		
+
+		// token_ttl: a blank value means "inherit the app / platform default", so
+		// drop the key entirely rather than persisting an empty/0 value (0 would
+		// mean "never expires").
+		const tokenTtl = cleanedAuthConfig?.session_policy?.token_ttl;
+		if (tokenTtl === '' || tokenTtl === null || tokenTtl === undefined) {
+			if (cleanedAuthConfig?.session_policy) {
+				delete cleanedAuthConfig.session_policy.token_ttl;
+			}
+		}
+
 		if (Object.keys(cleanedAuthConfig).length === 0) {
 			console.warn('No configuration changes to save');
 			return;
@@ -773,6 +788,25 @@ const AuthConfigurationForm = () => {
 															value={values?.session_policy?.max_concurrent_sessions}
 															onChange={(e) => setFieldValue("session_policy.max_concurrent_sessions", parseInt(e.target.value) || 0)}
 														/>
+														<div>
+															<InputField
+																name="session_policy.token_ttl"
+																label="Token Expiry (seconds)"
+																type="number"
+																placeholder="Inherit platform default"
+																value={values?.session_policy?.token_ttl ?? ""}
+																onChange={(e) => {
+																	const raw = e.target.value;
+																	setFieldValue(
+																		"session_policy.token_ttl",
+																		raw === "" ? "" : parseInt(raw)
+																	);
+																}}
+															/>
+															<p className="mt-[6px] font-lato text-form-xs text-[#A3ABB1]">
+																Lifetime of API auth tokens. 0 = never expires. Leave blank to inherit the platform default.
+															</p>
+														</div>
 														<ToggleCard
 															title="Force Logout on Password Change"
 															description="Automatically log out all sessions when password changes"

--- a/frontend/src/utils/tokenTtl.js
+++ b/frontend/src/utils/tokenTtl.js
@@ -1,0 +1,69 @@
+// Helpers for the auth token TTL (token_ttl), stored internally as seconds.
+// 0 = "never expires"; '' / null / undefined = "inherit platform default".
+
+export const TTL_UNITS = [
+	{ key: 'seconds', label: 'Seconds', seconds: 1 },
+	{ key: 'minutes', label: 'Minutes', seconds: 60 },
+	{ key: 'hours', label: 'Hours', seconds: 3600 },
+	{ key: 'days', label: 'Days', seconds: 86400 },
+];
+
+// Convert a (value, unit) pair to a whole number of seconds.
+export const ttlToSeconds = (value, unit) => {
+	const u = TTL_UNITS.find((x) => x.key === unit) || TTL_UNITS[0];
+	const num = parseInt(value);
+	if (Number.isNaN(num)) return '';
+	return num * u.seconds;
+};
+
+// Split a seconds value into the largest unit that divides it evenly, so an
+// existing value is shown in the most natural unit (e.g. 86400 -> 1 day).
+export const splitTtlSeconds = (seconds) => {
+	if (seconds === '' || seconds === null || seconds === undefined) {
+		return { value: '', unit: 'seconds' };
+	}
+	if (seconds === 0) return { value: 0, unit: 'seconds' };
+	// Largest unit first.
+	for (let i = TTL_UNITS.length - 1; i >= 0; i--) {
+		const u = TTL_UNITS[i];
+		if (seconds % u.seconds === 0) {
+			return { value: seconds / u.seconds, unit: u.key };
+		}
+	}
+	return { value: seconds, unit: 'seconds' };
+};
+
+// Map a stored token_ttl value to the editor "mode".
+//   '' / null / undefined -> 'default' (inherit platform default)
+//   0                      -> 'never'
+//   > 0                    -> 'custom'
+export const ttlMode = (seconds) => {
+	if (seconds === '' || seconds === null || seconds === undefined) return 'default';
+	if (seconds === 0) return 'never';
+	return 'custom';
+};
+
+// Human-readable label for a stored seconds value, adapting the unit.
+// Returns a sentinel string for the inherit / never cases.
+export const humanizeTokenTtl = (seconds) => {
+	if (seconds === '' || seconds === null || seconds === undefined) {
+		return 'Platform default';
+	}
+	if (seconds === 0) return 'Never expires';
+	const { value, unit } = splitTtlSeconds(seconds);
+	const u = TTL_UNITS.find((x) => x.key === unit) || TTL_UNITS[0];
+	const label = value === 1 ? u.label.replace(/s$/, '') : u.label;
+	return `${value} ${label.toLowerCase()}`;
+};
+
+// Like humanizeTokenTtl, but for read-only displays that also know the platform
+// default. When the value is inherited, shows e.g. "Platform default (1 day)".
+export const humanizeTokenTtlWithDefault = (seconds, platformDefault) => {
+	if (seconds === '' || seconds === null || seconds === undefined) {
+		if (platformDefault === undefined || platformDefault === null) {
+			return 'Platform default';
+		}
+		return `Platform default (${humanizeTokenTtl(platformDefault)})`;
+	}
+	return humanizeTokenTtl(seconds);
+};


### PR DESCRIPTION
## Overview

Admins can now control **how long API auth tokens stay valid** on a per-app and per-role basis, directly from the App Panel's Auth Config — instead of being stuck with a single platform-wide expiry for everyone.

## Why this matters

Until now, token expiry was one global value shared by every app and every role. A high-trust internal tool and a public-facing integration had to use the same token lifetime, and a sensitive Admin role couldn't be given a shorter session than a read-only role. This change lets each app — and each role within an app — tune token expiry to its own security needs.

## What you can do now

**Set token expiry per app**
- A new **Session & Tokens** step in the Auth Config setup lets you choose the token lifetime for the whole app.

**Override token expiry per role**
- In a role's override settings, you can set a stricter (or looser) token expiry just for users logging in with that role.

**Three clear choices, no guesswork**
- **Inherit the default** — use the app's value, or the platform default if the app hasn't set one.
- **Never expires** — tokens stay valid indefinitely.
- **Custom** — pick any duration in **seconds, minutes, hours, or days** (you no longer have to think in raw seconds).

**See the effective value everywhere**
- The inherit option shows the actual value it falls back to, e.g. *"Platform default (1 day)"* — and for a role, *"App default (1 hour)"* when the app has its own override.
- All summary and review screens show expiry in a human-friendly form (*"7 days"*, *"Never expires"*) instead of a bare number of seconds.
- Role override badges now display the configured value at a glance.

## How it resolves

When a user logs in, the token expiry is picked in this order:

> **Role setting → App setting → Platform default (`ZANGO_TOKEN_TTL`)**

The first level that has a value wins.

## Safe to ship

- **Nothing changes for existing apps or roles.** If a value isn't set, behaviour is exactly the same as before — the platform default is used.
- **No database migration** required.
- **Already-issued tokens are untouched** — a new expiry only applies to tokens issued after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)