### PR TITLE
feat(code_execution): raise timeout upper bound from 300s to 24h

### DIFF
--- a/backend/src/zango/api/platform/code_execution/v1/serializers.py
+++ b/backend/src/zango/api/platform/code_execution/v1/serializers.py
@@ -112,9 +112,12 @@ class CodeSnippetWriteSerializer(serializers.ModelSerializer):
         fields = ("name", "description", "code", "timeout_seconds")
 
     def validate_timeout_seconds(self, value):
-        if value < 5 or value > 300:
+        # 24-hour upper bound covers realistic long-running batch snippets
+        # while still capping a rogue snippet from tying up a celery slot
+        # indefinitely.
+        if value < 5 or value > 86400:
             raise serializers.ValidationError(
-                "timeout_seconds must be between 5 and 300."
+                "timeout_seconds must be between 5 and 86400."
             )
         return value
 

--- a/frontend/src/pages/appCode/components/CodeExecution/EditorModal.jsx
+++ b/frontend/src/pages/appCode/components/CodeExecution/EditorModal.jsx
@@ -299,7 +299,7 @@ export default function EditorModal({ appId, snippet, onClose, onSaved }) {
 										<input
 											type="number"
 											min={5}
-											max={300}
+											max={86400}
 											value={timeoutSeconds}
 											onChange={(e) => setTimeoutSeconds(e.target.value)}
 											className="w-full px-3 py-2 text-[13px] border border-slate-300 rounded-md focus:outline-none focus:border-[#346BD4]"


### PR DESCRIPTION
## Motivation

Real batch snippets — bulk cleanup jobs, data migrations, cross-model sweeps — legitimately need runtimes beyond the previous 5-minute (300s) ceiling. Users were being forced to split single logical jobs into artificial chunks or work around the cap with retries.

## Change

Raise the upper bound on \`CodeSnippet.timeout_seconds\` from 300 to 86400 (24 hours) in both the backend validator and the frontend input.

### Backend

\`backend/src/zango/api/platform/code_execution/v1/serializers.py\`

\`\`\`diff
 def validate_timeout_seconds(self, value):
-    if value < 5 or value > 300:
+    # 24-hour upper bound covers realistic long-running batch snippets
+    # while still capping a rogue snippet from tying up a celery slot
+    # indefinitely.
+    if value < 5 or value > 86400:
         raise serializers.ValidationError(
-            "timeout_seconds must be between 5 and 300."
+            "timeout_seconds must be between 5 and 86400."
         )
     return value
\`\`\`

### Frontend

\`frontend/src/pages/appCode/components/CodeExecution/EditorModal.jsx\`

\`\`\`diff
 <input
     type="number"
     min={5}
-    max={300}
+    max={86400}
     ...
 />
\`\`\`

## Why 24 hours instead of no cap at all

Removing the upper bound entirely would let a misconfigured snippet enter something like \`999999999\` and tie up a celery worker slot for years. 24 hours is generous enough for any realistic batch use case while still bounding worst-case pool depletion.

## What stays unchanged

- **Minimum stays at 5s** — existing snippets are unaffected. No migration or data change needed.
- **Model default stays at 60s** — new snippets still start with a safe default.
- **Celery mechanics unchanged** — \`soft_time_limit\` and \`time_limit\` in the dispatch view already use \`snippet.timeout_seconds\` directly, so they inherit the new cap automatically.
- **DB-level isolation session** (statement_timeout in \`begin_isolated_session\`) already computes from the same field.

## Ops note (out of scope for this PR)

For snippets that actually run in the multi-hour range, worth double-checking celery broker config on staging — some \`worker_shutdown_timeout\` / \`visibility_timeout\` values could kill or redeliver a long task before it finishes. That's a deployment-side check, not a code change.

## Test plan

- [ ] Create a snippet with \`timeout_seconds=3600\` (1 hour) — save succeeds, previously rejected
- [ ] Create a snippet with \`timeout_seconds=86400\` (24 hours) — save succeeds
- [ ] Create a snippet with \`timeout_seconds=86401\` — rejected with the new error message
- [ ] Create a snippet with \`timeout_seconds=4\` — rejected (min unchanged)
- [ ] Existing snippets with \`timeout_seconds\` between 5 and 300 continue to save and run identically
- [ ] Frontend input allows values up to 86400 without native validation error

## Files touched

- \`backend/src/zango/api/platform/code_execution/v1/serializers.py\` (+5 / -2)
- \`frontend/src/pages/appCode/components/CodeExecution/EditorModal.jsx\` (+1 / -1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)