### PR TITLE
prepare release 1.2.0b6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 * Dispatch code execution task after transaction commit + alias workspace imports [(#600)](https://github.com/Healthlane-Technologies/Zango/pull/600)
-* Fix AI cost calculation for global model IDs [(#597)](https://github.com/Healthlane-Technologies/Zango/pull/597)
 
 ## [1.2.0b5] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0b6] - 2026-07-02
+
+### Added
+
+* App- and role-level auth token TTL configuration [(#601)](https://github.com/Healthlane-Technologies/Zango/pull/601)
+* Raise code execution timeout upper bound from 300s to 24h [(#602)](https://github.com/Healthlane-Technologies/Zango/pull/602)
+
+### Fixed
+
+* Dispatch code execution task after transaction commit + alias workspace imports [(#600)](https://github.com/Healthlane-Technologies/Zango/pull/600)
+* Fix AI cost calculation for global model IDs [(#597)](https://github.com/Healthlane-Technologies/Zango/pull/597)
+
 ## [1.2.0b5] - 2026-06-18
 
 ### Fixed

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -7,7 +7,7 @@ PROJECT_DIR = os.path.dirname(__file__)
 REQUIREMENTS_DIR = os.path.join(PROJECT_DIR, "requirements")
 README = os.path.join(PROJECT_DIR, "README.md")
 
-PLATFORM_VERSION = "1.2.0b5"
+PLATFORM_VERSION = "1.2.0b6"
 
 
 def get_requirements(env):

--- a/backend/src/zango/__init__.py
+++ b/backend/src/zango/__init__.py
@@ -2,4 +2,4 @@ from zango.core import internal_requests
 
 
 __all__ = ["internal_requests"]
-__version__ = "1.2.0b5"
+__version__ = "1.2.0b6"


### PR DESCRIPTION
## Summary

Bumps version from `1.2.0b5` → `1.2.0b6` and updates the changelog.

### Changes included since 1.2.0b5

**Added**
- App- and role-level auth token TTL configuration ([#601](https://github.com/Healthlane-Technologies/Zango/pull/601))
- Raise code execution timeout upper bound from 300s to 24h ([#602](https://github.com/Healthlane-Technologies/Zango/pull/602))

**Fixed**
- Dispatch code execution task after transaction commit + alias workspace imports ([#600](https://github.com/Healthlane-Technologies/Zango/pull/600))
- Fix AI cost calculation for global model IDs ([#597](https://github.com/Healthlane-Technologies/Zango/pull/597))

## Files changed
- `backend/setup.py` — version bump
- `backend/src/zango/__init__.py` — version bump
- `CHANGELOG.md` — new `[1.2.0b6]` section

🤖 Generated with [Claude Code](https://claude.com/claude-code)