### PR TITLE
feat(tenancy): app suspension — block traffic + background tasks

### DIFF
--- a/backend/docs/app-suspension-plan.html
+++ b/backend/docs/app-suspension-plan.html
@@ -1,0 +1,1204 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+<title>App Suspension · Design + Implementation Plan | Zango Platform</title>
+
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..700&family=JetBrains+Mono:wght@400;500;600&family=Instrument+Serif:ital@0;1&display=swap" rel="stylesheet">
+
+<style>
+:root {
+  --surface-page:     #F6F7FB;
+  --surface-card:     #FFFFFF;
+  --surface-sunken:   #F0F2F7;
+  --surface-tinted:   #EEF1FE;
+  --surface-rail:     #FAFBFD;
+  --surface-code:     #0F1117;
+  --surface-hero:     #14172A;
+
+  --text-strong:   #0B0D14;
+  --text-primary:  #14172A;
+  --text-body:     #2C3047;
+  --text-muted:    #5A607A;
+  --text-subtle:   #8389A3;
+  --text-inverse:  #E5E7EE;
+  --text-inverse-muted: rgba(230,232,240,.68);
+
+  --border-strong: #D4D8E5;
+  --border:        #E3E6EF;
+  --border-soft:   #ECEEF5;
+
+  --indigo-50:#EEF1FE; --indigo-100:#DCE3FD; --indigo-500:#5961E5; --indigo-700:#3938B5; --indigo-900:#20207A;
+  --teal-50:#EAFAF7; --teal-500:#119C85; --teal-700:#0D6555;
+  --sage-50:#EFF7EE; --sage-500:#5AA45B; --sage-700:#36713A;
+  --amber-50:#FEF6E7; --amber-100:#FCEAC4; --amber-500:#DA9011; --amber-700:#8A5A07; --amber-900:#5A3B04;
+  --crimson-50:#FCEDEF; --crimson-100:#F8D5D9; --crimson-500:#D3424E; --crimson-700:#931F2A;
+  --slate-50:#F4F5F8; --slate-500:#6E748D; --slate-700:#3D4159;
+
+  --brand: var(--indigo-500);
+  --brand-soft: var(--indigo-50);
+  --accent: var(--teal-500);
+  --status-suspended: var(--amber-500);
+  --status-suspended-soft: var(--amber-50);
+  --status-active: var(--sage-500);
+  --status-active-soft: var(--sage-50);
+
+  --r-sm:6px; --r-md:8px; --r-lg:10px; --r-xl:12px; --r-2xl:16px; --r-pill:999px;
+
+  --shadow-sm: 0 1px 2px rgba(15,19,36,.06);
+  --shadow-md: 0 4px 12px -2px rgba(15,19,36,.08), 0 2px 4px rgba(15,19,36,.04), inset 0 1px 0 rgba(255,255,255,.6);
+  --shadow-lg: 0 12px 32px -8px rgba(15,19,36,.14), 0 4px 8px rgba(15,19,36,.05), inset 0 1px 0 rgba(255,255,255,.6);
+  --shadow-amber: 0 8px 24px -6px rgba(218,144,17,.22), 0 2px 4px rgba(218,144,17,.08);
+
+  --ease-out: cubic-bezier(.22,1,.36,1);
+  --ease-spring: cubic-bezier(.34,1.28,.64,1);
+  --font: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
+  --font-display: 'Instrument Serif', 'Times New Roman', serif;
+}
+
+* { box-sizing: border-box; margin: 0; padding: 0; }
+html { font-size: 14px; scroll-behavior: smooth; }
+body {
+  font-family: var(--font);
+  font-feature-settings: 'cv11','ss01','ss03';
+  font-optical-sizing: auto;
+  -webkit-font-smoothing: antialiased;
+  background: var(--surface-page);
+  color: var(--text-body);
+  line-height: 1.55;
+}
+
+.shell { max-width: 1180px; margin: 0 auto; padding: 40px 32px 96px; }
+
+/* ============== HERO ============== */
+.hero {
+  position: relative;
+  padding: 56px 56px 52px;
+  border-radius: 20px;
+  overflow: hidden;
+  background:
+    radial-gradient(120% 100% at 100% 0%, rgba(218,144,17,.22), transparent 55%),
+    radial-gradient(90% 80% at 0% 100%, rgba(89,97,229,.20), transparent 55%),
+    linear-gradient(140deg, #14172A 0%, #1B1D3B 55%, #2A2C6B 100%);
+  color: var(--text-inverse);
+  margin-bottom: 48px;
+  box-shadow: 0 20px 60px -20px rgba(15,19,36,.35), inset 0 1px 0 rgba(255,255,255,.06);
+  animation: fadeUp 460ms var(--ease-out) both;
+}
+.hero-grid { display: grid; grid-template-columns: 1.35fr .95fr; gap: 44px; align-items: start; }
+@media (max-width: 900px) { .hero-grid { grid-template-columns: 1fr; } }
+.hero-kicker {
+  display: inline-flex; align-items: center; gap: 8px;
+  font-size: 10.5px; letter-spacing: .14em; text-transform: uppercase; font-weight: 600;
+  color: rgba(252,237,239,.85); margin-bottom: 20px;
+}
+.hero-kicker::before {
+  content: ''; width: 6px; height: 6px; border-radius: 50%;
+  background: var(--amber-500); box-shadow: 0 0 0 3px rgba(218,144,17,.22);
+  animation: pulse 2.4s ease-in-out infinite;
+}
+.hero h1 {
+  font-size: 42px; font-weight: 600; letter-spacing: -0.032em; line-height: 1.05;
+  color: #FFFFFF; margin-bottom: 18px; max-width: 640px;
+}
+.hero h1 em { font-family: var(--font-display); font-style: italic; font-weight: 400; color: var(--amber-100); }
+.hero p.lede {
+  font-size: 15px; color: var(--text-inverse-muted); line-height: 1.65; max-width: 60ch;
+}
+.hero-meta { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 28px; }
+.hero-chip {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 6px 12px; border-radius: var(--r-pill);
+  font-size: 11.5px; font-weight: 500;
+  background: rgba(230,232,240,.08); border: 1px solid rgba(230,232,240,.14);
+  color: rgba(230,232,240,.9);
+}
+.hero-chip.amber { background: rgba(218,144,17,.18); border-color: rgba(218,144,17,.32); color: var(--amber-100); }
+.hero-chip.teal { background: rgba(17,156,133,.16); border-color: rgba(17,156,133,.32); color: #A5EBDD; }
+
+.hero-preview {
+  padding: 22px 20px;
+  border-radius: 14px;
+  background: rgba(15,17,23,.55);
+  border: 1px solid rgba(230,232,240,.10);
+  backdrop-filter: blur(8px);
+}
+.hero-preview .label {
+  display: block; font-size: 9.5px; letter-spacing: .11em; text-transform: uppercase; font-weight: 600;
+  color: rgba(230,232,240,.55); margin-bottom: 12px;
+}
+.mini-404 {
+  background: #FEF6E7;
+  border: 1px solid rgba(218,144,17,.28);
+  border-radius: 10px;
+  padding: 18px 20px;
+  text-align: center;
+  color: var(--amber-900);
+}
+.mini-404 .icon {
+  width: 44px; height: 44px; margin: 0 auto 10px;
+  border-radius: 50%; background: rgba(218,144,17,.16); display: grid; place-items: center;
+}
+.mini-404 h4 { font-size: 15px; font-weight: 600; color: var(--amber-900); margin-bottom: 4px; letter-spacing: -0.015em; }
+.mini-404 p { font-size: 12.5px; color: rgba(90,58,4,.72); line-height: 1.5; }
+
+/* ============== SECTIONS ============== */
+section { margin-bottom: 64px; scroll-margin-top: 24px; animation: fadeUp 380ms var(--ease-out) both; }
+section > .kicker {
+  display: inline-block; font-size: 10.5px; letter-spacing: .11em; text-transform: uppercase;
+  font-weight: 600; color: var(--brand); margin-bottom: 10px;
+}
+section h2 {
+  font-size: 28px; font-weight: 600; letter-spacing: -0.024em; color: var(--text-strong);
+  margin-bottom: 12px; line-height: 1.15;
+}
+section .lede { font-size: 14.5px; color: var(--text-muted); max-width: 68ch; margin-bottom: 28px; line-height: 1.6; }
+
+h3 {
+  font-size: 17px; font-weight: 600; color: var(--text-strong);
+  letter-spacing: -0.012em; margin-bottom: 10px; margin-top: 24px;
+}
+h4 {
+  font-size: 12.5px; font-weight: 600; color: var(--text-strong);
+  letter-spacing: .04em; text-transform: uppercase; margin: 18px 0 8px;
+}
+
+p { color: var(--text-body); font-size: 13.5px; line-height: 1.62; }
+p + p { margin-top: 8px; }
+ul, ol { padding-left: 22px; margin: 8px 0 12px; }
+li { color: var(--text-body); font-size: 13.5px; margin-bottom: 5px; line-height: 1.55; }
+li b, strong { color: var(--text-strong); font-weight: 600; }
+
+/* ============== CARDS + LAYOUTS ============== */
+.card {
+  background: var(--surface-card);
+  border: 1px solid var(--border);
+  border-radius: var(--r-xl);
+  padding: 24px 28px;
+  box-shadow: var(--shadow-sm);
+  margin-bottom: 16px;
+}
+.card.tinted { background: var(--surface-tinted); border-color: var(--indigo-100); }
+.card.sunken { background: var(--surface-sunken); box-shadow: none; }
+.card.amber-tinted { background: var(--amber-50); border-color: var(--amber-100); }
+.card.sage-tinted { background: var(--sage-50); border-color: rgba(90,164,91,.28); }
+
+.grid-2 { display: grid; grid-template-columns: 1fr 1fr; gap: 20px; margin: 16px 0; }
+.grid-2.uneven { grid-template-columns: 1.35fr 1fr; }
+@media (max-width: 800px) { .grid-2, .grid-2.uneven { grid-template-columns: 1fr; } }
+
+.grid-3 { display: grid; grid-template-columns: repeat(3, 1fr); gap: 16px; margin: 16px 0; }
+@media (max-width: 800px) { .grid-3 { grid-template-columns: 1fr; } }
+
+/* ============== JOURNEY DIAGRAM ============== */
+.journey {
+  display: grid; grid-template-columns: 1fr auto 1fr auto 1fr; gap: 14px; align-items: stretch;
+  margin: 20px 0 8px;
+}
+@media (max-width: 900px) { .journey { grid-template-columns: 1fr; } .journey-arrow { display: none; } }
+.journey-step {
+  background: var(--surface-card); border: 1px solid var(--border);
+  border-radius: var(--r-lg); padding: 20px; position: relative;
+  box-shadow: var(--shadow-sm);
+}
+.journey-step.state-suspend { border-color: var(--amber-100); background: linear-gradient(180deg, var(--amber-50) 0%, #FFFFFF 60%); }
+.journey-step.state-block { border-color: var(--indigo-100); background: linear-gradient(180deg, var(--indigo-50) 0%, #FFFFFF 60%); }
+.journey-step .num {
+  display: inline-flex; align-items: center; justify-content: center;
+  width: 24px; height: 24px; border-radius: 50%;
+  background: var(--brand); color: white;
+  font-size: 11px; font-weight: 600; font-family: var(--font-mono);
+  margin-bottom: 10px;
+}
+.journey-step.state-suspend .num { background: var(--amber-500); }
+.journey-step .title { font-size: 13.5px; font-weight: 600; color: var(--text-strong); margin-bottom: 6px; letter-spacing: -0.008em; }
+.journey-step .detail { font-size: 12px; color: var(--text-muted); line-height: 1.55; }
+.journey-arrow {
+  display: grid; place-items: center; color: var(--border-strong); font-size: 20px;
+}
+
+/* ============== MOCKUP FRAMES ============== */
+.mockup {
+  background: var(--surface-card);
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  overflow: hidden;
+  box-shadow: var(--shadow-lg);
+  margin: 20px 0;
+}
+.mockup-chrome {
+  background: var(--surface-sunken);
+  border-bottom: 1px solid var(--border);
+  padding: 10px 16px;
+  display: flex; align-items: center; gap: 8px;
+}
+.mockup-dot { width: 10px; height: 10px; border-radius: 50%; background: var(--border-strong); }
+.mockup-dot.r { background: #FF6058; }
+.mockup-dot.y { background: #FFC130; }
+.mockup-dot.g { background: #29CE41; }
+.mockup-url {
+  margin-left: 12px; padding: 5px 12px; border-radius: 6px;
+  background: white; border: 1px solid var(--border); flex: 1;
+  font-family: var(--font-mono); font-size: 11px; color: var(--text-muted);
+}
+.mockup-body { padding: 40px; background: var(--surface-page); }
+
+/* The star of the show: the branded 404 page */
+.suspended-page {
+  background: var(--surface-card);
+  border-radius: var(--r-2xl);
+  padding: 64px 56px 56px;
+  max-width: 560px; margin: 0 auto;
+  text-align: center;
+  box-shadow: var(--shadow-md);
+  border: 1px solid var(--border);
+  position: relative; overflow: hidden;
+}
+.suspended-page::before {
+  content: ''; position: absolute; top: 0; left: 0; right: 0; height: 3px;
+  background: linear-gradient(90deg, var(--amber-500) 0%, var(--brand) 100%);
+}
+.suspended-badge {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 6px 14px; border-radius: var(--r-pill);
+  background: var(--amber-50); border: 1px solid var(--amber-100);
+  font-size: 11px; letter-spacing: .09em; text-transform: uppercase; font-weight: 600;
+  color: var(--amber-700);
+  margin-bottom: 24px;
+}
+.suspended-badge::before {
+  content: ''; width: 6px; height: 6px; border-radius: 50%;
+  background: var(--amber-500); box-shadow: 0 0 0 3px rgba(218,144,17,.24);
+}
+.suspended-icon {
+  width: 72px; height: 72px; margin: 0 auto 22px;
+  border-radius: 20px;
+  background: linear-gradient(140deg, #FEF6E7 0%, #FCEAC4 100%);
+  border: 1px solid var(--amber-100);
+  display: grid; place-items: center;
+  color: var(--amber-700);
+  box-shadow: var(--shadow-amber);
+}
+.suspended-page h2 {
+  font-size: 32px; font-weight: 600; letter-spacing: -0.028em; line-height: 1.1;
+  color: var(--text-strong); margin-bottom: 12px;
+}
+.suspended-page h2 em { font-family: var(--font-display); font-style: italic; font-weight: 400; color: var(--amber-700); }
+.suspended-page .msg {
+  font-size: 14.5px; color: var(--text-muted); line-height: 1.6;
+  max-width: 42ch; margin: 0 auto 32px;
+}
+.suspended-page .actions {
+  display: flex; gap: 12px; justify-content: center;
+  padding-top: 24px; border-top: 1px solid var(--border-soft);
+}
+.btn-primary {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 10px 20px; border-radius: var(--r-md);
+  background: var(--text-strong); color: white;
+  font-size: 13px; font-weight: 500; text-decoration: none;
+  transition: transform 180ms var(--ease-out), box-shadow 180ms var(--ease-out);
+  box-shadow: 0 2px 6px -1px rgba(15,19,36,.24);
+}
+.btn-primary:hover { transform: translateY(-1px); box-shadow: 0 4px 12px -2px rgba(15,19,36,.32); }
+.btn-secondary {
+  display: inline-flex; align-items: center; gap: 8px;
+  padding: 10px 20px; border-radius: var(--r-md);
+  background: white; color: var(--text-body);
+  border: 1px solid var(--border-strong);
+  font-size: 13px; font-weight: 500; text-decoration: none;
+  transition: all 180ms var(--ease-out);
+}
+.btn-secondary:hover { background: var(--surface-sunken); border-color: var(--text-muted); }
+.suspended-meta {
+  margin-top: 28px; padding-top: 20px; border-top: 1px dashed var(--border);
+  font-size: 11.5px; color: var(--text-subtle); font-family: var(--font-mono);
+}
+
+/* Admin panel mockup */
+.admin-panel {
+  background: var(--surface-page);
+  padding: 24px 28px;
+}
+.admin-panel h4 { font-size: 15px; text-transform: none; letter-spacing: -0.012em; color: var(--text-strong); margin-bottom: 4px; font-weight: 600; }
+.admin-sub { font-size: 12.5px; color: var(--text-muted); margin-bottom: 18px; }
+
+.app-row {
+  display: grid; grid-template-columns: 40px 1fr auto auto; gap: 14px;
+  align-items: center;
+  background: var(--surface-card); border: 1px solid var(--border);
+  border-radius: var(--r-lg); padding: 14px 16px; margin-bottom: 8px;
+  transition: all 180ms var(--ease-out);
+}
+.app-row:hover { border-color: var(--border-strong); box-shadow: var(--shadow-sm); }
+.app-row.suspended { background: linear-gradient(90deg, var(--amber-50) 0%, #FFFFFF 30%); border-color: var(--amber-100); }
+.app-avatar {
+  width: 40px; height: 40px; border-radius: 8px;
+  background: linear-gradient(140deg, var(--indigo-500) 0%, var(--indigo-700) 100%);
+  color: white; display: grid; place-items: center;
+  font-weight: 600; font-size: 15px;
+  box-shadow: 0 2px 6px -1px rgba(89,97,229,.35);
+}
+.app-avatar.amber { background: linear-gradient(140deg, var(--amber-500) 0%, #B87608 100%); box-shadow: 0 2px 6px -1px rgba(218,144,17,.4); }
+.app-avatar.teal { background: linear-gradient(140deg, var(--teal-500) 0%, var(--teal-700) 100%); box-shadow: 0 2px 6px -1px rgba(17,156,133,.4); }
+.app-name { font-size: 13.5px; font-weight: 600; color: var(--text-strong); letter-spacing: -0.006em; }
+.app-domain { font-size: 11.5px; color: var(--text-subtle); font-family: var(--font-mono); margin-top: 2px; }
+.status-pill {
+  display: inline-flex; align-items: center; gap: 6px;
+  padding: 3px 9px; border-radius: var(--r-pill);
+  font-size: 10.5px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase;
+  white-space: nowrap;
+}
+.status-pill::before { content: ''; width: 6px; height: 6px; border-radius: 50%; }
+.status-pill.active { background: var(--sage-50); color: var(--sage-700); }
+.status-pill.active::before { background: var(--sage-500); box-shadow: 0 0 0 2px rgba(90,164,91,.24); }
+.status-pill.suspended { background: var(--amber-50); color: var(--amber-700); }
+.status-pill.suspended::before { background: var(--amber-500); box-shadow: 0 0 0 2px rgba(218,144,17,.24); }
+
+.app-actions {
+  display: flex; gap: 4px;
+  opacity: .0; transition: opacity 180ms var(--ease-out);
+}
+.app-row:hover .app-actions { opacity: 1; }
+.app-row.suspended .app-actions { opacity: 1; }
+.action-btn {
+  padding: 6px 10px; border-radius: 6px;
+  font-size: 11.5px; font-weight: 500;
+  border: 1px solid var(--border-strong); background: white;
+  color: var(--text-body); cursor: pointer;
+  transition: all 140ms var(--ease-out);
+}
+.action-btn:hover { border-color: var(--text-muted); background: var(--surface-sunken); }
+.action-btn.danger { color: var(--amber-700); border-color: var(--amber-100); background: var(--amber-50); }
+.action-btn.danger:hover { background: #FCEAC4; border-color: var(--amber-500); }
+.action-btn.primary { color: white; background: var(--brand); border-color: var(--indigo-700); }
+.action-btn.primary:hover { background: var(--indigo-700); }
+
+/* Confirmation dialog mockup */
+.confirm-dialog {
+  background: var(--surface-card);
+  border-radius: var(--r-2xl);
+  padding: 32px 32px 28px;
+  max-width: 460px; margin: 0 auto;
+  box-shadow: var(--shadow-lg);
+  border: 1px solid var(--border);
+}
+.confirm-icon {
+  width: 48px; height: 48px; border-radius: 12px;
+  background: var(--amber-50); border: 1px solid var(--amber-100);
+  display: grid; place-items: center; color: var(--amber-700);
+  margin-bottom: 18px;
+}
+.confirm-dialog h4 { font-size: 18px; text-transform: none; letter-spacing: -0.015em; margin-bottom: 8px; }
+.confirm-dialog p { font-size: 13px; color: var(--text-muted); margin-bottom: 20px; line-height: 1.55; }
+.confirm-input-label { display: block; font-size: 11px; letter-spacing: .06em; text-transform: uppercase; font-weight: 600; color: var(--text-subtle); margin-bottom: 6px; }
+.confirm-input {
+  width: 100%; padding: 9px 12px; border-radius: 8px;
+  border: 1px solid var(--border-strong); background: var(--surface-sunken);
+  font-size: 13px; font-family: var(--font-mono); color: var(--text-body);
+  outline: none; margin-bottom: 20px;
+  transition: border-color 140ms var(--ease-out), background-color 140ms var(--ease-out);
+}
+.confirm-input:focus { border-color: var(--brand); background: white; }
+.confirm-actions { display: flex; gap: 10px; justify-content: flex-end; }
+
+/* ============== CODE BLOCKS ============== */
+.code-card {
+  background: var(--surface-code);
+  border-radius: var(--r-lg);
+  overflow: hidden;
+  margin: 12px 0;
+  border: 1px solid #22252F;
+}
+.code-header {
+  padding: 8px 14px;
+  background: rgba(255,255,255,.03);
+  border-bottom: 1px solid rgba(255,255,255,.06);
+  display: flex; align-items: center; justify-content: space-between;
+  font-family: var(--font-mono); font-size: 11px;
+}
+.code-path { color: rgba(230,232,240,.72); }
+.code-badge {
+  padding: 2px 8px; border-radius: 4px; font-size: 9.5px;
+  letter-spacing: .07em; text-transform: uppercase; font-weight: 600;
+}
+.code-badge.new { background: rgba(161,232,154,.15); color: #A1E89A; }
+.code-badge.mod { background: rgba(255,203,107,.15); color: #FFCB6B; }
+pre {
+  padding: 16px 18px; color: #E1E4ED;
+  font-family: var(--font-mono); font-size: 11.5px; line-height: 1.65;
+  overflow-x: auto;
+}
+.tok-kw { color: #C792EA; }
+.tok-fn { color: #82AAFF; }
+.tok-str { color: #C3E88D; }
+.tok-num { color: #F78C6C; }
+.tok-com { color: #6E748D; font-style: italic; }
+.tok-cls { color: #FFCB6B; }
+.tok-add { color: #A1E89A; }
+.tok-del { color: #FF8B9C; }
+.tok-add-line { background: rgba(161,232,154,.06); display: block; margin: 0 -18px; padding: 0 18px; }
+.tok-del-line { background: rgba(255,139,156,.06); display: block; margin: 0 -18px; padding: 0 18px; }
+
+/* Callouts */
+.callout {
+  padding: 16px 20px; border-radius: var(--r-md);
+  border: 1px solid; margin: 18px 0;
+  font-size: 13px;
+}
+.callout.note { background: var(--indigo-50); border-color: var(--indigo-100); color: var(--text-body); }
+.callout.warn { background: var(--amber-50); border-color: var(--amber-100); color: var(--amber-900); }
+.callout.tip { background: var(--sage-50); border-color: rgba(90,164,91,.28); color: var(--sage-700); }
+.callout-title { font-weight: 600; font-size: 12px; letter-spacing: .04em; text-transform: uppercase; margin-bottom: 6px; }
+.callout.note .callout-title { color: var(--indigo-700); }
+.callout.warn .callout-title { color: var(--amber-700); }
+.callout.tip .callout-title { color: var(--sage-700); }
+
+/* Impact tiles */
+.impact-row { display: grid; grid-template-columns: 1.5fr 1fr 1fr 1fr; gap: 12px; margin: 20px 0 12px; }
+@media (max-width: 800px) { .impact-row { grid-template-columns: 1fr 1fr; } }
+.impact-tile {
+  background: var(--surface-card); border: 1px solid var(--border); border-radius: var(--r-lg);
+  padding: 16px 18px 14px; box-shadow: var(--shadow-sm);
+}
+.impact-tile.hero-tile {
+  background: linear-gradient(140deg, var(--indigo-500) 0%, var(--indigo-700) 100%);
+  color: white; border-color: transparent;
+  box-shadow: 0 6px 20px -4px rgba(89,97,229,.4), inset 0 1px 0 rgba(255,255,255,.15);
+}
+.impact-tile .label {
+  font-size: 10px; letter-spacing: .09em; text-transform: uppercase; font-weight: 600;
+  color: var(--text-subtle); margin-bottom: 8px;
+}
+.impact-tile.hero-tile .label { color: rgba(255,255,255,.72); }
+.impact-tile .value { font-size: 22px; font-weight: 600; letter-spacing: -0.02em; color: var(--text-strong); line-height: 1; }
+.impact-tile.hero-tile .value { color: white; font-size: 24px; }
+.impact-tile .sub { font-size: 11.5px; color: var(--text-muted); margin-top: 6px; }
+.impact-tile.hero-tile .sub { color: rgba(255,255,255,.7); }
+
+/* Timeline */
+.rollout {
+  display: grid; grid-template-columns: 20px 1fr; gap: 16px;
+  margin: 24px 0;
+  position: relative;
+}
+.rollout-item {
+  display: grid; grid-template-columns: 20px 1fr; gap: 16px;
+  padding-bottom: 24px;
+  position: relative;
+}
+.rollout-item:not(:last-child)::before {
+  content: ''; position: absolute; left: 9px; top: 20px; bottom: -4px;
+  width: 2px; background: var(--border);
+}
+.rollout-dot {
+  width: 20px; height: 20px; border-radius: 50%;
+  background: white; border: 3px solid var(--brand);
+  margin-top: 2px; z-index: 1; position: relative;
+  box-shadow: 0 0 0 4px rgba(89,97,229,.10);
+}
+.rollout-body h4 { text-transform: none; letter-spacing: -0.008em; font-size: 14.5px; margin-top: 0; }
+.rollout-body p { font-size: 13px; color: var(--text-muted); margin-top: 4px; }
+
+/* Test plan checklist */
+.test-list { list-style: none; padding: 0; }
+.test-list li {
+  padding: 10px 14px; margin-bottom: 6px;
+  background: var(--surface-card); border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  font-size: 12.5px; color: var(--text-body);
+  display: flex; align-items: flex-start; gap: 10px;
+}
+.test-list li::before {
+  content: ''; width: 14px; height: 14px; border-radius: 3px;
+  border: 1.5px solid var(--border-strong); flex-shrink: 0; margin-top: 1px;
+}
+
+footer {
+  margin-top: 72px; padding: 32px 0 0;
+  border-top: 1px solid var(--border);
+  text-align: center; font-size: 12px; color: var(--text-subtle);
+}
+footer code { font-family: var(--font-mono); background: var(--surface-sunken); padding: 1px 6px; border-radius: 4px; color: var(--text-body); }
+
+/* Inline code */
+code { font-family: var(--font-mono); font-size: 12px; background: var(--surface-sunken); padding: 1px 6px; border-radius: 4px; color: var(--text-strong); }
+
+/* Motion */
+@keyframes fadeUp { from { opacity: 0; transform: translateY(6px); } to { opacity: 1; transform: none; } }
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: .4; } }
+@media (prefers-reduced-motion: reduce) {
+  * { animation: none !important; transition-duration: .01ms !important; }
+}
+</style>
+</head>
+<body>
+
+<div class="shell">
+
+<!-- ============== HERO ============== -->
+<div class="hero">
+  <div class="hero-grid">
+    <div>
+      <div class="hero-kicker">Zango Platform · design + implementation plan</div>
+      <h1>App suspension — block traffic to <em>suspended</em> tenants, gracefully.</h1>
+      <p class="lede">
+        Platform admins should be able to suspend an app and instantly stop all traffic — HTTP requests, background tasks, worker jobs — while keeping the schema and data intact. Users who try to reach a suspended app see a calm, branded message telling them to contact support. This is a plan document: what to build, how the UX reads, and the exact code changes needed.
+      </p>
+      <div class="hero-meta">
+        <span class="hero-chip amber">Status field exists · enforcement missing</span>
+        <span class="hero-chip">2 backend files · 3 frontend files</span>
+        <span class="hero-chip teal">~180 LOC total</span>
+      </div>
+    </div>
+
+    <div class="hero-preview">
+      <span class="label">Preview · the 404 page</span>
+      <div class="mini-404">
+        <div class="icon">
+          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.4" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="11" width="18" height="10" rx="2"/><path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+          </svg>
+        </div>
+        <h4>This app is suspended</h4>
+        <p>Please contact support for access. Data is preserved.</p>
+      </div>
+    </div>
+  </div>
+</div>
+
+<!-- ============== IMPACT AT-A-GLANCE ============== -->
+<section>
+  <span class="kicker">01 · At a glance</span>
+  <h2>Scope + impact</h2>
+  <div class="impact-row">
+    <div class="impact-tile hero-tile">
+      <div class="label">One-line summary</div>
+      <div class="value" style="font-size:15px; line-height:1.35;">Enforce suspend at the middleware boundary. Show a branded 404 page. Add a suspend action in the platform apps list.</div>
+    </div>
+    <div class="impact-tile">
+      <div class="label">Backend files</div>
+      <div class="value">2</div>
+      <div class="sub">Middleware + template</div>
+    </div>
+    <div class="impact-tile">
+      <div class="label">Frontend files</div>
+      <div class="value">3</div>
+      <div class="sub">List row + dialog + action</div>
+    </div>
+    <div class="impact-tile">
+      <div class="label">DB migrations</div>
+      <div class="value">0</div>
+      <div class="sub">Model already supports it</div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== WHAT'S ALREADY THERE ============== -->
+<section>
+  <span class="kicker">02 · Foundation</span>
+  <h2>What already exists — and what doesn't</h2>
+  <p class="lede">
+    The <code>TenantModel</code> already carries a <code>status</code> field with <code>"suspended"</code> as one of the values, a <code>suspended_on</code> timestamp, and a <code>suspend()</code> method. What's missing is <strong>enforcement</strong>, <strong>the branded landing page</strong>, and <strong>the admin action</strong>.
+  </p>
+
+  <div class="grid-2 uneven">
+    <div class="card sage-tinted">
+      <h4 style="margin-top:0; color: var(--sage-700);">Already in place</h4>
+      <ul style="margin-top: 10px;">
+        <li><code>TenantModel.status</code> — enum with <code>Staged</code>, <code>Deployed</code>, <code>Suspended</code>, <code>Deleted</code></li>
+        <li><code>TenantModel.suspended_on</code> — datetime, nullable</li>
+        <li><code>TenantModel.suspend()</code> — sets status + timestamp, saves</li>
+        <li>Tenant resolution middleware (<code>ZangoTenantMainMiddleware</code>) that identifies the tenant per request</li>
+        <li>Platform apps list API + frontend page for admins</li>
+      </ul>
+    </div>
+    <div class="card amber-tinted">
+      <h4 style="margin-top:0; color: var(--amber-700);">What's missing</h4>
+      <ul style="margin-top: 10px;">
+        <li>Middleware check on <code>tenant.status</code> — currently traffic flows through regardless</li>
+        <li>The branded 404 template</li>
+        <li>An <code>unsuspend()</code> method (symmetric with <code>suspend()</code>)</li>
+        <li>Platform admin API for suspend / unsuspend</li>
+        <li>Frontend suspend action, confirmation dialog, and status badge</li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ============== USER JOURNEY ============== -->
+<section>
+  <span class="kicker">03 · User journey</span>
+  <h2>Two flows, one graceful outcome</h2>
+
+  <h3>Flow A — Admin suspends an app</h3>
+  <div class="journey">
+    <div class="journey-step">
+      <div class="num">1</div>
+      <div class="title">Admin visits Platform Apps</div>
+      <div class="detail">Sees the app list with status badges. Active apps show a green pill; suspended apps show an amber pill.</div>
+    </div>
+    <div class="journey-arrow">→</div>
+    <div class="journey-step state-suspend">
+      <div class="num">2</div>
+      <div class="title">Clicks Suspend</div>
+      <div class="detail">A confirmation dialog appears. Requires typing the app name to prevent misclicks. Explains that data is preserved.</div>
+    </div>
+    <div class="journey-arrow">→</div>
+    <div class="journey-step">
+      <div class="num">3</div>
+      <div class="title">Status flips instantly</div>
+      <div class="detail">Row updates with the amber pill. From this moment, all traffic to the app hits the branded 404 page.</div>
+    </div>
+  </div>
+
+  <h3 style="margin-top: 40px;">Flow B — End user visits a suspended app</h3>
+  <div class="journey">
+    <div class="journey-step">
+      <div class="num">1</div>
+      <div class="title">User visits app URL</div>
+      <div class="detail">Any path — login, dashboard, API endpoint, deep link — resolves the tenant as usual.</div>
+    </div>
+    <div class="journey-arrow">→</div>
+    <div class="journey-step state-block">
+      <div class="num">2</div>
+      <div class="title">Middleware short-circuits</div>
+      <div class="detail">Before the URL resolver runs, the middleware sees <code>status == "suspended"</code> and returns the suspended-page response with HTTP 404.</div>
+    </div>
+    <div class="journey-arrow">→</div>
+    <div class="journey-step state-suspend">
+      <div class="num">3</div>
+      <div class="title">User sees a calm message</div>
+      <div class="detail">Not a scary error — a branded page saying "this app is suspended" with a support contact CTA.</div>
+    </div>
+  </div>
+</section>
+
+<!-- ============== THE 404 PAGE MOCKUP ============== -->
+<section>
+  <span class="kicker">04 · The suspended page</span>
+  <h2>A calm, branded 404 — not a hostile error</h2>
+  <p class="lede">
+    HTTP 404 with a designed body. Amber accents, not red. Icon suggests "locked, but recoverable." Copy avoids blame. A single primary CTA to contact support keeps the page uncluttered. Data preservation is stated explicitly so anxious users don't panic.
+  </p>
+
+  <div class="mockup">
+    <div class="mockup-chrome">
+      <span class="mockup-dot r"></span>
+      <span class="mockup-dot y"></span>
+      <span class="mockup-dot g"></span>
+      <div class="mockup-url">https://myapp.zango.io/dashboard</div>
+    </div>
+    <div class="mockup-body">
+      <div class="suspended-page">
+        <div class="suspended-badge">App unavailable</div>
+        <div class="suspended-icon">
+          <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <rect x="3" y="11" width="18" height="10" rx="2"/>
+            <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+          </svg>
+        </div>
+        <h2>This app is currently <em>suspended</em></h2>
+        <p class="msg">
+          Access to this application has been paused by the platform administrator. Your data is preserved and unchanged. Please contact support if you believe this is in error.
+        </p>
+        <div class="suspended-meta">Reference · myapp.zango.io · 404</div>
+      </div>
+    </div>
+  </div>
+
+  <div class="callout tip">
+    <div class="callout-title">Design decisions</div>
+    <p><strong>Amber not red:</strong> red reads as "system error" or "danger." Amber says "attention needed" without alarm. <strong>Serif italic on "suspended":</strong> the one word that carries the meaning gets typographic weight. <strong>"Your data is preserved":</strong> the most common panic — "did I lose my data?" — answered before the user asks. <strong>No CTA:</strong> a "contact support" button is tempting but the support channel is out-of-band (email, phone). The message tells users to contact support; the URL bar is where they go to another destination. Keeping the page action-free preserves calm and avoids stale mailto: links.</p>
+  </div>
+</section>
+
+<!-- ============== ADMIN PANEL MOCKUP ============== -->
+<section>
+  <span class="kicker">05 · Admin UX</span>
+  <h2>Suspending an app from Platform → Apps</h2>
+  <p class="lede">
+    Suspension lives inline in the existing apps list, not on a separate settings page. Admins see status at a glance via colored pills, and the action is one hover + one click + one confirmation away. The confirmation dialog requires typing the app name — enough friction to prevent accidents without being annoying.
+  </p>
+
+  <div class="grid-2 uneven">
+    <div>
+      <h4>The apps list</h4>
+      <div class="mockup">
+        <div class="mockup-chrome">
+          <span class="mockup-dot r"></span>
+          <span class="mockup-dot y"></span>
+          <span class="mockup-dot g"></span>
+          <div class="mockup-url">/platform/apps</div>
+        </div>
+        <div class="admin-panel">
+          <h4>Apps</h4>
+          <div class="admin-sub">All tenant applications in this workspace.</div>
+
+          <div class="app-row">
+            <div class="app-avatar">P</div>
+            <div>
+              <div class="app-name">Pharmacovigilance</div>
+              <div class="app-domain">pv.zango.io</div>
+            </div>
+            <span class="status-pill active">Active</span>
+            <div class="app-actions">
+              <button class="action-btn">Open</button>
+              <button class="action-btn danger">Suspend</button>
+            </div>
+          </div>
+
+          <div class="app-row suspended">
+            <div class="app-avatar amber">C</div>
+            <div>
+              <div class="app-name">Cadence</div>
+              <div class="app-domain">cadence.zango.io</div>
+            </div>
+            <span class="status-pill suspended">Suspended</span>
+            <div class="app-actions">
+              <button class="action-btn primary">Unsuspend</button>
+            </div>
+          </div>
+
+          <div class="app-row">
+            <div class="app-avatar teal">M</div>
+            <div>
+              <div class="app-name">MedRec Portal</div>
+              <div class="app-domain">medrec.zango.io</div>
+            </div>
+            <span class="status-pill active">Active</span>
+            <div class="app-actions">
+              <button class="action-btn">Open</button>
+              <button class="action-btn danger">Suspend</button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div>
+      <h4>Confirmation dialog</h4>
+      <div class="confirm-dialog">
+        <div class="confirm-icon">
+          <svg width="22" height="22" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z"/>
+            <line x1="12" y1="9" x2="12" y2="13"/>
+            <line x1="12" y1="17" x2="12.01" y2="17"/>
+          </svg>
+        </div>
+        <h4>Suspend "Cadence"?</h4>
+        <p>
+          All traffic to <strong>cadence.zango.io</strong> will be blocked with a support-contact message. Data is preserved and can be restored anytime by unsuspending.
+        </p>
+        <label class="confirm-input-label">Type the app name to confirm</label>
+        <input class="confirm-input" placeholder="Cadence" value="Cadence">
+        <div class="confirm-actions">
+          <button class="btn-secondary">Cancel</button>
+          <button class="btn-primary" style="background: var(--amber-500); box-shadow: 0 2px 6px -1px rgba(218,144,17,.4);">Suspend app</button>
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <div class="callout note">
+    <div class="callout-title">Why type-to-confirm</div>
+    <p>Modal confirmations get click-through rates near 100% when they're just "Are you sure?" buttons. Requiring the exact app name adds ~2 seconds of friction but essentially eliminates accidental suspensions. Same pattern as GitHub's repo-deletion flow. The button stays disabled until the input matches.</p>
+  </div>
+</section>
+
+<!-- ============== BACKEND IMPLEMENTATION ============== -->
+<section>
+  <span class="kicker">06 · Backend implementation</span>
+  <h2>Middleware guard + branded template</h2>
+  <p class="lede">
+    Enforcement lives in <code>ZangoTenantMainMiddleware.__call__</code>, right after tenant resolution and before URL routing. A single conditional check on <code>tenant.status</code> short-circuits the request. The response is a rendered template returned with HTTP 404 so it's cacheable by CDNs and consistent with how other "resource unavailable" cases behave.
+  </p>
+
+  <h3>Change 1 · Middleware guard</h3>
+
+  <div class="code-card">
+    <div class="code-header">
+      <span class="code-path">backend/src/zango/middleware/tenant.py · ~line 96</span>
+      <span class="code-badge mod">modified</span>
+    </div>
+<pre><span class="tok-kw">def</span> <span class="tok-fn">__call__</span>(<span class="tok-cls">self</span>, request):
+    connection.set_schema_to_public()
+    <span class="tok-com"># ... existing hostname + tenant resolution ...</span>
+
+    tenant.domain_url = hostname
+    request.tenant = tenant
+    request.internal_routing = <span class="tok-num">False</span>
+    connection.set_tenant(request.tenant)
+
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-com"># Suspend guard — short-circuit any request to a suspended tenant.</span></span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-com"># Health check + platform-admin routes are exempt so the platform</span></span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-com"># operator can still unsuspend from the admin UI.</span></span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-kw">if</span> tenant.status == <span class="tok-str">"suspended"</span> <span class="tok-kw">and</span> <span class="tok-kw">not</span> <span class="tok-cls">self</span>._is_exempt_path(request):</span>
+<span class="tok-add-line"><span class="tok-add">+</span>        <span class="tok-kw">return</span> render(</span>
+<span class="tok-add-line"><span class="tok-add">+</span>            request,</span>
+<span class="tok-add-line"><span class="tok-add">+</span>            <span class="tok-str">"tenancy/app_suspended.html"</span>,</span>
+<span class="tok-add-line"><span class="tok-add">+</span>            {<span class="tok-str">"tenant"</span>: tenant, <span class="tok-str">"support_email"</span>: settings.SUPPORT_EMAIL},</span>
+<span class="tok-add-line"><span class="tok-add">+</span>            status=<span class="tok-num">404</span>,</span>
+<span class="tok-add-line"><span class="tok-add">+</span>        )</span>
+
+    <span class="tok-cls">self</span>.setup_url_routing(request)
+    <span class="tok-kw">return</span> <span class="tok-cls">self</span>.get_response(request)
+
+<span class="tok-add-line"><span class="tok-add">+</span><span class="tok-kw">def</span> <span class="tok-fn">_is_exempt_path</span>(<span class="tok-cls">self</span>, request):</span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-str">"""Paths that continue to work even when a tenant is suspended:</span></span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-str">health checks (so load balancers don't mark the app as down)</span></span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-str">and platform-admin API endpoints (so the operator can unsuspend)."""</span></span>
+<span class="tok-add-line"><span class="tok-add">+</span>    exempt_prefixes = (</span>
+<span class="tok-add-line"><span class="tok-add">+</span>        <span class="tok-str">"/api/v1/health/"</span>,</span>
+<span class="tok-add-line"><span class="tok-add">+</span>        <span class="tok-str">"/api/v1/platform/"</span>,</span>
+<span class="tok-add-line"><span class="tok-add">+</span>    )</span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-kw">return</span> <span class="tok-fn">any</span>(request.path.<span class="tok-fn">startswith</span>(p) <span class="tok-kw">for</span> p <span class="tok-kw">in</span> exempt_prefixes)</span></pre>
+  </div>
+
+  <div class="callout warn">
+    <div class="callout-title">Exempt paths are load-bearing</div>
+    <p>Two exemptions matter: (a) <strong>health checks</strong> — if <code>/api/v1/health/</code> returns 404, your load balancer marks the app as unhealthy and pages someone at 3am; (b) <strong>platform admin API</strong> — if <code>/api/v1/platform/*</code> returns 404, the operator can't unsuspend from the admin UI they just navigated to. Both exemptions must ship together with the middleware change.</p>
+  </div>
+
+  <h3>Change 2 · Suspended-page template</h3>
+
+  <div class="code-card">
+    <div class="code-header">
+      <span class="code-path">backend/src/zango/apps/shared/tenancy/templates/tenancy/app_suspended.html</span>
+      <span class="code-badge new">new</span>
+    </div>
+<pre><span class="tok-com">{% load static %}</span>
+<span class="tok-cls">&lt;!DOCTYPE html&gt;</span>
+<span class="tok-cls">&lt;html lang="en"&gt;</span>
+<span class="tok-cls">&lt;head&gt;</span>
+    <span class="tok-cls">&lt;meta charset="UTF-8"&gt;</span>
+    <span class="tok-cls">&lt;title&gt;</span>App unavailable — <span class="tok-com">{{ tenant.name }}</span><span class="tok-cls">&lt;/title&gt;</span>
+    <span class="tok-cls">&lt;link rel="icon" href="{% static 'favicon.ico' %}"&gt;</span>
+    <span class="tok-cls">&lt;style&gt;</span>
+        <span class="tok-com">/* Inline the entire suspended-page component from the mockup above.</span>
+        <span class="tok-com">   No external CSS — must work even if static files are misconfigured. */</span>
+    <span class="tok-cls">&lt;/style&gt;</span>
+<span class="tok-cls">&lt;/head&gt;</span>
+<span class="tok-cls">&lt;body&gt;</span>
+    <span class="tok-cls">&lt;div</span> class=<span class="tok-str">"suspended-page"</span><span class="tok-cls">&gt;</span>
+        <span class="tok-com">{# amber badge, lock icon, headline, message, CTA — see mockup #}</span>
+    <span class="tok-cls">&lt;/div&gt;</span>
+<span class="tok-cls">&lt;/body&gt;</span>
+<span class="tok-cls">&lt;/html&gt;</span></pre>
+  </div>
+
+  <h3>Change 3 · <code>unsuspend()</code> method (symmetric with existing <code>suspend()</code>)</h3>
+
+  <div class="code-card">
+    <div class="code-header">
+      <span class="code-path">backend/src/zango/apps/shared/tenancy/models.py · after line 133</span>
+      <span class="code-badge mod">modified</span>
+    </div>
+<pre><span class="tok-kw">def</span> <span class="tok-fn">suspend</span>(<span class="tok-cls">self</span>):
+    <span class="tok-cls">self</span>.status = <span class="tok-str">"suspended"</span>
+    <span class="tok-cls">self</span>.suspended_on = timezone.<span class="tok-fn">now</span>()
+    <span class="tok-cls">self</span>.<span class="tok-fn">save</span>()
+
+<span class="tok-add-line"><span class="tok-add">+</span><span class="tok-kw">def</span> <span class="tok-fn">unsuspend</span>(<span class="tok-cls">self</span>):</span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-str">"""Restore a suspended tenant to deployed status. Traffic resumes</span></span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-str">immediately on the next request."""</span></span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-cls">self</span>.status = <span class="tok-str">"deployed"</span></span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-cls">self</span>.suspended_on = <span class="tok-num">None</span></span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-cls">self</span>.<span class="tok-fn">save</span>()</span></pre>
+  </div>
+
+  <h3>Change 4 · Platform admin API endpoint</h3>
+
+  <p>
+    Single view for both actions. The action name lives in the URL — so logs, curl invocations, and audit trails all read at a glance without body inspection. Symmetric suspend / unsuspend collapse into one <code>getattr(tenant, action)()</code> call. Adding a future status action (<code>archive</code>, <code>rotate-keys</code>) is a one-line addition to the allowlist.
+  </p>
+
+  <div class="code-card">
+    <div class="code-header">
+      <span class="code-path">backend/src/zango/api/platform/apps/v1/views.py</span>
+      <span class="code-badge new">new</span>
+    </div>
+<pre><span class="tok-kw">class</span> <span class="tok-cls">AppStatusActionView</span>(<span class="tok-cls">ZangoGenericPlatformAPIView</span>):
+    <span class="tok-str">"""POST /api/v1/platform/apps/&lt;app_uuid&gt;/status/&lt;action&gt;/</span>
+
+    <span class="tok-str">action ∈ {"suspend", "unsuspend"}.</span>
+    <span class="tok-str">"""</span>
+    permission_classes = (<span class="tok-cls">IsSuperAdminPlatformUser</span>,)
+
+    _ALLOWED_ACTIONS = (<span class="tok-str">"suspend"</span>, <span class="tok-str">"unsuspend"</span>)
+
+    <span class="tok-kw">def</span> <span class="tok-fn">post</span>(<span class="tok-cls">self</span>, request, app_uuid, action):
+        <span class="tok-kw">if</span> action <span class="tok-kw">not in</span> <span class="tok-cls">self</span>._ALLOWED_ACTIONS:
+            <span class="tok-kw">return</span> <span class="tok-fn">get_api_response</span>(
+                <span class="tok-num">False</span>,
+                {<span class="tok-str">"message"</span>: <span class="tok-fn">f</span><span class="tok-str">"Unknown action '{action}'."</span>},
+                <span class="tok-num">400</span>,
+            )
+        tenant = <span class="tok-fn">get_object_or_404</span>(<span class="tok-cls">TenantModel</span>, uuid=app_uuid)
+        <span class="tok-fn">getattr</span>(tenant, action)()  <span class="tok-com"># tenant.suspend() or tenant.unsuspend()</span>
+        <span class="tok-kw">return</span> <span class="tok-fn">get_api_response</span>(
+            <span class="tok-num">True</span>,
+            {<span class="tok-str">"tenant"</span>: <span class="tok-cls">TenantSerializer</span>(tenant).data},
+            <span class="tok-num">200</span>,
+        )</pre>
+  </div>
+
+  <div class="code-card">
+    <div class="code-header">
+      <span class="code-path">backend/src/zango/api/platform/apps/v1/urls.py</span>
+      <span class="code-badge mod">modified</span>
+    </div>
+<pre><span class="tok-fn">path</span>(
+    <span class="tok-str">"apps/&lt;uuid:app_uuid&gt;/status/&lt;str:action&gt;/"</span>,
+    <span class="tok-cls">AppStatusActionView</span>.<span class="tok-fn">as_view</span>(),
+    name=<span class="tok-str">"platform-app-status-action"</span>,
+),</pre>
+  </div>
+
+  <div class="callout tip">
+    <div class="callout-title">Why one view, not two</div>
+    <p><strong>Read at a glance:</strong> \`POST /apps/&lt;uuid&gt;/status/suspend/\` reads as a command in logs, curl, and API docs. <strong>DRY body:</strong> the only difference between suspend and unsuspend is which method is called — <code>getattr</code> collapses that into a single line, no if/else duplication. <strong>Extensible:</strong> adding <code>archive</code> or <code>rotate-keys</code> in the future is one line in <code>_ALLOWED_ACTIONS</code> plus the matching method on the model. <strong>Auditable:</strong> the URL path is enough to distinguish suspend from unsuspend in access logs — no body parsing needed.</p>
+  </div>
+</section>
+
+<!-- ============== FRONTEND IMPLEMENTATION ============== -->
+<section>
+  <span class="kicker">07 · Frontend implementation</span>
+  <h2>Inline suspend action + status badge</h2>
+  <p class="lede">
+    Three surgical changes in the existing apps list — no new page, no route. Status badges appear next to app names, hover reveals a Suspend button on active apps and an Unsuspend button on suspended ones, and the confirmation dialog matches Zango's existing modal pattern.
+  </p>
+
+  <h3>Change 1 · Status badge component</h3>
+
+  <div class="code-card">
+    <div class="code-header">
+      <span class="code-path">frontend/src/pages/platform/components/StatusPill.jsx</span>
+      <span class="code-badge new">new</span>
+    </div>
+<pre><span class="tok-kw">export function</span> <span class="tok-fn">StatusPill</span>({ status }) {
+  <span class="tok-kw">const</span> variant = {
+    deployed:  { label: <span class="tok-str">'Active'</span>,    cls: <span class="tok-str">'active'</span> },
+    suspended: { label: <span class="tok-str">'Suspended'</span>, cls: <span class="tok-str">'suspended'</span> },
+    staged:    { label: <span class="tok-str">'Staged'</span>,    cls: <span class="tok-str">'staged'</span> },
+    deleted:   { label: <span class="tok-str">'Deleted'</span>,   cls: <span class="tok-str">'deleted'</span> },
+  }[status] || { label: status, cls: <span class="tok-str">'default'</span> };
+
+  <span class="tok-kw">return</span> (
+    &lt;span className={<span class="tok-str">`status-pill ${variant.cls}`</span>}&gt;
+      {variant.label}
+    &lt;/span&gt;
+  );
+}</pre>
+  </div>
+
+  <h3>Change 2 · Suspend action + confirmation dialog</h3>
+
+  <div class="code-card">
+    <div class="code-header">
+      <span class="code-path">frontend/src/pages/platform/components/SuspendAppDialog.jsx</span>
+      <span class="code-badge new">new</span>
+    </div>
+<pre><span class="tok-kw">export function</span> <span class="tok-fn">SuspendAppDialog</span>({ app, onClose, onSuspended }) {
+  <span class="tok-kw">const</span> [typedName, setTypedName] = <span class="tok-fn">useState</span>(<span class="tok-str">''</span>);
+  <span class="tok-kw">const</span> [busy, setBusy] = <span class="tok-fn">useState</span>(<span class="tok-num">false</span>);
+  <span class="tok-kw">const</span> triggerApi = <span class="tok-fn">useApi</span>();
+
+  <span class="tok-kw">const</span> matches = typedName.<span class="tok-fn">trim</span>() === app.name;
+
+  <span class="tok-kw">const</span> handleSuspend = <span class="tok-kw">async</span> () => {
+    <span class="tok-kw">if</span> (!matches || busy) <span class="tok-kw">return</span>;
+    <span class="tok-fn">setBusy</span>(<span class="tok-num">true</span>);
+    <span class="tok-kw">const</span> { success } = <span class="tok-kw">await</span> <span class="tok-fn">triggerApi</span>({
+      url: <span class="tok-str">`/api/v1/platform/apps/${app.uuid}/suspend/`</span>,
+      type: <span class="tok-str">'POST'</span>,
+    });
+    <span class="tok-kw">if</span> (success) <span class="tok-fn">onSuspended</span>();
+    <span class="tok-fn">setBusy</span>(<span class="tok-num">false</span>);
+  };
+
+  <span class="tok-com">// Render the confirm-dialog mockup from section 05.</span>
+  <span class="tok-com">// Primary button disabled unless matches === true.</span>
+}</pre>
+  </div>
+
+  <h3>Change 3 · Wire into the apps list row</h3>
+
+  <p>In the existing apps list (<code>pages/platform/…/AppList.jsx</code> or equivalent), add the status pill to each row and the Suspend / Unsuspend action to the hover-revealed action cluster. The Suspend action opens <code>SuspendAppDialog</code>; the Unsuspend action fires the unsuspend API directly (no confirmation — resuming service is low-risk).</p>
+</section>
+
+<!-- ============== EDGE CASES ============== -->
+<section>
+  <span class="kicker">08 · Edge cases</span>
+  <h2>What happens when…</h2>
+
+  <div class="grid-2">
+    <div class="card">
+      <h4 style="margin-top:0;">Platform admin themselves visits the suspended app?</h4>
+      <p style="font-size: 13px; margin-top: 6px;">They still see the 404 page for the app's public URL. To interact with the tenant, they use the platform-admin API endpoints (which are exempt) — this includes the unsuspend action.</p>
+    </div>
+
+    <div class="card">
+      <h4 style="margin-top:0;">An API client with cached auth token calls a suspended app?</h4>
+      <p style="font-size: 13px; margin-top: 6px;">They get HTTP 404 with the branded HTML body. If the client only reads status codes, a 404 correctly signals "not available." If they parse HTML, they see the same page a browser sees.</p>
+    </div>
+
+    <div class="card">
+      <h4 style="margin-top:0;">A load balancer health check hits the app?</h4>
+      <p style="font-size: 13px; margin-top: 6px;"><code>/api/v1/health/</code> is exempt from the suspend guard, returns 200 as normal. Load balancers don't mark suspended apps as unhealthy.</p>
+    </div>
+
+    <div class="card">
+      <h4 style="margin-top:0;">CDN caches the suspended page?</h4>
+      <p style="font-size: 13px; margin-top: 6px;">HTTP 404 is cacheable but short-TTL by default. If your CDN caches longer, add <code>Cache-Control: max-age=60</code> to the response so unsuspend takes effect within a minute rather than hours.</p>
+    </div>
+  </div>
+</section>
+
+<!-- ============== CELERY / BACKGROUND WORK ============== -->
+<section>
+  <span class="kicker">09 · Celery + background work</span>
+  <h2>Blocking traffic isn't enough — background work needs its own guard</h2>
+  <p class="lede">
+    HTTP middleware only sees HTTP requests. Celery tasks execute in worker processes and don't touch the middleware chain, so a middleware-only fix leaves several task sources unblocked: scheduled Celery Beat jobs, task chains that spawn from other tasks, workspace tasks (defined in <code>workspaces/&lt;tenant&gt;/…/tasks.py</code>), and codexec runs enqueued before the tenant was suspended. Each source has a different failure mode and a different fix.
+  </p>
+
+  <h3>The four sources — and what happens to each</h3>
+
+  <div class="grid-2" style="margin-top: 18px;">
+    <div class="card">
+      <h4 style="margin-top:0;">A · HTTP-dispatched tasks</h4>
+      <p style="font-size: 13px; margin-top: 6px;">A view calls <code>my_task.apply_async(...)</code>. Because the suspend guard returns 404 before the view body runs, the dispatch never happens. <b>No additional work needed — middleware already covers this.</b></p>
+    </div>
+
+    <div class="card">
+      <h4 style="margin-top:0;">B · Celery Beat scheduled tasks</h4>
+      <p style="font-size: 13px; margin-top: 6px;">Zango has <code>health_check_periodic_task</code>, <code>update_tool_usage_stats</code>, and workspace beat schedules. These fire on a cron regardless of HTTP traffic. If the tenant is suspended, they'd still execute against the tenant's schema — writing data, sending emails, whatever the task does. <b>Needs a task-entry guard.</b></p>
+    </div>
+
+    <div class="card">
+      <h4 style="margin-top:0;">C · Task chains + retries</h4>
+      <p style="font-size: 13px; margin-top: 6px;">A task that finishes with <code>next_task.apply_async(...)</code> spawns the next one from inside a worker. If the tenant is suspended between the parent and child, the child would still run. Same for retries scheduled with <code>self.retry(countdown=...)</code>. <b>Needs a task-entry guard.</b></p>
+    </div>
+
+    <div class="card">
+      <h4 style="margin-top:0;">D · In-flight tasks at the moment of suspension</h4>
+      <p style="font-size: 13px; margin-top: 6px;">A codexec run halfway through, or an email task that's mid-SMTP-send. Killing these mid-execution would leave DB rows in inconsistent states. <b>Let them complete — no kill.</b></p>
+    </div>
+  </div>
+
+  <h3 style="margin-top: 32px;">Framework-level enforcement — two chokepoints, no decorators</h3>
+  <p style="font-size: 13px; color: var(--text-muted); max-width: 68ch;">
+    Requiring every task author to remember a decorator is fragile — someone will forget and the guarantee silently breaks. Instead, enforce the check in the two places every tenant-scoped task naturally passes through. Both are single-line additions in Zango core code. Task authors don't need to know this exists.
+  </p>
+
+  <div class="grid-2" style="margin-top: 20px;">
+    <div class="card sage-tinted">
+      <h4 style="margin-top:0; color: var(--sage-700);">Chokepoint 1 · zango_task_executor</h4>
+      <p style="font-size: 12.5px; margin-top: 6px;"><b>Every workspace task</b> runs through <code>zango.core.tasks.zango_task_executor</code> — email/OTP/SMS sends, workspace-defined tasks, beat-scheduled workspace tasks, task chains, retries. The wrapper sets the tenant, then invokes the workspace-defined function via <code>plugin_source.load_plugin</code>. Adding the assertion right after <code>connection.set_tenant(tenant)</code> covers 100% of these.</p>
+    </div>
+    <div class="card sage-tinted">
+      <h4 style="margin-top:0; color: var(--sage-700);">Chokepoint 2 · codexec_executor</h4>
+      <p style="font-size: 12.5px; margin-top: 6px;">Codexec has its own task that sets the tenant and runs the user's snippet — it doesn't route through <code>zango_task_executor</code>. Add the same assertion here, immediately after <code>set_tenant</code>. One line.</p>
+    </div>
+  </div>
+
+  <h3 style="margin-top: 32px;">The shared utility</h3>
+
+  <div class="code-card">
+    <div class="code-header">
+      <span class="code-path">backend/src/zango/apps/shared/tenancy/utils.py</span>
+      <span class="code-badge new">new</span>
+    </div>
+<pre><span class="tok-kw">from</span> django.db <span class="tok-kw">import</span> connection
+<span class="tok-kw">from</span> loguru <span class="tok-kw">import</span> logger
+
+
+<span class="tok-kw">class</span> <span class="tok-cls">TenantSuspended</span>(<span class="tok-cls">Exception</span>):
+    <span class="tok-str">"""Raised when a Celery task is invoked against a suspended tenant.</span>
+    <span class="tok-str">Celery treats this as a task failure — the broker acknowledges the</span>
+    <span class="tok-str">message and the failure is recorded. A future dispatch after</span>
+    <span class="tok-str">unsuspend runs normally."""</span>
+
+
+<span class="tok-kw">def</span> <span class="tok-fn">assert_tenant_active</span>(tenant=<span class="tok-num">None</span>):
+    <span class="tok-str">"""Raise TenantSuspended if the (given or current-connection) tenant</span>
+    <span class="tok-str">is suspended. Cheap — one attribute lookup, no DB roundtrip."""</span>
+    tenant = tenant <span class="tok-kw">or</span> <span class="tok-fn">getattr</span>(connection, <span class="tok-str">"tenant"</span>, <span class="tok-num">None</span>)
+    <span class="tok-kw">if</span> tenant <span class="tok-kw">is not</span> <span class="tok-num">None</span> <span class="tok-kw">and</span> tenant.status == <span class="tok-str">"suspended"</span>:
+        logger.<span class="tok-fn">info</span>(
+            <span class="tok-str">"Task skipped: tenant '{}' is suspended"</span>,
+            tenant.schema_name,
+        )
+        <span class="tok-kw">raise</span> <span class="tok-cls">TenantSuspended</span>(tenant.schema_name)</pre>
+  </div>
+
+  <h3 style="margin-top: 32px;">Chokepoint 1 · zango_task_executor</h3>
+  <p style="font-size: 13px; color: var(--text-muted); max-width: 68ch;">
+    Reading the actual <code>zango.core.tasks:zango_task_executor</code>: it accepts <code>tenant_name</code> as its first argument, sets the connection to that tenant, then loads the workspace and dispatches to the workspace-defined function. Every workspace task — regardless of how it was enqueued (HTTP view, beat schedule, chain, retry) — passes through this wrapper. One assertion right after <code>set_tenant</code> covers all of them.
+  </p>
+
+  <div class="code-card">
+    <div class="code-header">
+      <span class="code-path">backend/src/zango/core/tasks.py</span>
+      <span class="code-badge mod">modified</span>
+    </div>
+<pre>@<span class="tok-fn">shared_task</span>
+<span class="tok-kw">def</span> <span class="tok-fn">zango_task_executor</span>(tenant_name, task_name, *args, timezone_name=<span class="tok-num">None</span>, **kwargs):
+    <span class="tok-com"># ... existing imports ...</span>
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-kw">from</span> zango.apps.shared.tenancy.utils <span class="tok-kw">import</span> assert_tenant_active</span>
+
+    tenant = <span class="tok-cls">TenantModel</span>.objects.<span class="tok-fn">get</span>(name=tenant_name)
+    connection.<span class="tok-fn">set_tenant</span>(tenant)
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-fn">assert_tenant_active</span>(tenant)  <span class="tok-com"># framework-level suspend guard</span></span>
+
+    <span class="tok-kw">with</span> connection.<span class="tok-fn">cursor</span>() <span class="tok-kw">as</span> c:
+        task_obj = <span class="tok-cls">AppTask</span>.objects.<span class="tok-fn">get</span>(name=task_name)
+        <span class="tok-com"># ... rest of the executor ...</span></pre>
+  </div>
+
+  <h3 style="margin-top: 24px;">Chokepoint 2 · codexec_executor</h3>
+  <p style="font-size: 13px; color: var(--text-muted); max-width: 68ch;">
+    Codexec has its own Celery task that doesn't route through <code>zango_task_executor</code>. Same one-line assertion, immediately after <code>set_tenant</code>. If a snippet was enqueued before the tenant was suspended and the flip happens while the task waited in the queue, the assertion catches it on pickup.
+  </p>
+
+  <div class="code-card">
+    <div class="code-header">
+      <span class="code-path">backend/src/zango/apps/code_execution/tasks.py — codexec_executor</span>
+      <span class="code-badge mod">modified</span>
+    </div>
+<pre>@<span class="tok-fn">shared_task</span>(bind=<span class="tok-num">True</span>, name=<span class="tok-str">"zango.code_execution.codexec_executor"</span>)
+<span class="tok-kw">def</span> <span class="tok-fn">codexec_executor</span>(<span class="tok-cls">self</span>, execution_uuid, tenant_name):
+    tenant = <span class="tok-cls">TenantModel</span>.objects.<span class="tok-fn">get</span>(name=tenant_name)
+    connection.<span class="tok-fn">set_tenant</span>(tenant)
+<span class="tok-add-line"><span class="tok-add">+</span>    <span class="tok-fn">assert_tenant_active</span>(tenant)  <span class="tok-com"># catches flip between enqueue and pickup</span></span>
+    execution = <span class="tok-cls">CodeExecution</span>.objects.<span class="tok-fn">get</span>(object_uuid=execution_uuid)
+    <span class="tok-com"># ... rest of the executor ...</span></pre>
+  </div>
+
+  <h3 style="margin-top: 28px;">What we do not do</h3>
+  <ul>
+    <li><b>We don't use a <code>task_prerun</code> signal.</b> Every tenant-scoped task in Zango passes through one of the two chokepoints above — the signal would be redundant, would need a platform-task skip-list to keep in sync with the actual task inventory, and would fire after Celery had already imported workspace code. The two explicit assertions are cheaper and clearer.</li>
+    <li><b>We don't purge the broker queue.</b> Tasks enqueued before suspension stay in Redis. Each is caught on pickup by one of the two chokepoints — <code>TenantSuspended</code> propagates as a task failure, the broker acknowledges the message, no retry loop.</li>
+    <li><b>We don't kill in-flight tasks.</b> Cancelling a mid-execution task with <code>revoke(terminate=True)</code> leaves the tenant's DB rows in whatever partial state the task had reached. Better to let a codexec run finish; the next dispatch is blocked.</li>
+    <li><b>We don't rely on per-task decorators.</b> Task authors don't have to remember anything. The framework enforces the guard at the two natural chokepoints.</li>
+  </ul>
+
+  <div class="callout tip">
+    <div class="callout-title">Why two chokepoints is enough</div>
+    <p>Every workspace task — email, OTP, SMS, workspace-defined, beat-scheduled, chained, retried — is routed to <code>zango_task_executor</code> by Zango's task registration machinery. The only exception is <code>codexec_executor</code>, which is a Zango core task that manages its own tenant context. Cover those two and there's nothing left to catch.</p>
+  </div>
+</section>
+
+<footer>
+  Design doc · Zango app suspension · uses <code>TenantModel.status</code> already in place ·
+  ~180 LOC across <code>middleware/tenant.py</code>, <code>tenancy/models.py</code>, <code>tenancy/utils.py</code>, <code>api/platform/apps/</code>, and <code>frontend/pages/platform/</code>.
+</footer>
+
+</div>
+</body>
+</html>

--- a/backend/src/zango/api/platform/tasks/v1/serializers.py
+++ b/backend/src/zango/api/platform/tasks/v1/serializers.py
@@ -31,25 +31,10 @@ class TaskSerializer(serializers.ModelSerializer):
     run_history = serializers.SerializerMethodField()
     created_at = serializers.SerializerMethodField()
     modified_at = serializers.SerializerMethodField()
-    # Runtime state (from the linked PeriodicTask). Diverges from
-    # `is_enabled` when the tenant is suspended — `is_enabled` stays as
-    # the operator set it, but `runtime_enabled` reflects whether beat
-    # will actually fire the task.
-    runtime_enabled = serializers.SerializerMethodField()
 
     class Meta:
         model = AppTask
         fields = "__all__"
-
-    def get_runtime_enabled(self, obj):
-        try:
-            if obj.master_task_id:
-                return PeriodicTask.objects.filter(
-                    id=obj.master_task_id
-                ).values_list("enabled", flat=True).first()
-        except Exception:
-            pass
-        return None
 
     def update(self, instance, validated_data):
         if self.context.get("cronexp"):

--- a/backend/src/zango/api/platform/tasks/v1/serializers.py
+++ b/backend/src/zango/api/platform/tasks/v1/serializers.py
@@ -31,10 +31,25 @@ class TaskSerializer(serializers.ModelSerializer):
     run_history = serializers.SerializerMethodField()
     created_at = serializers.SerializerMethodField()
     modified_at = serializers.SerializerMethodField()
+    # Runtime state (from the linked PeriodicTask). Diverges from
+    # `is_enabled` when the tenant is suspended — `is_enabled` stays as
+    # the operator set it, but `runtime_enabled` reflects whether beat
+    # will actually fire the task.
+    runtime_enabled = serializers.SerializerMethodField()
 
     class Meta:
         model = AppTask
         fields = "__all__"
+
+    def get_runtime_enabled(self, obj):
+        try:
+            if obj.master_task_id:
+                return PeriodicTask.objects.filter(
+                    id=obj.master_task_id
+                ).values_list("enabled", flat=True).first()
+        except Exception:
+            pass
+        return None
 
     def update(self, instance, validated_data):
         if self.context.get("cronexp"):

--- a/backend/src/zango/api/platform/tenancy/v1/urls.py
+++ b/backend/src/zango/api/platform/tenancy/v1/urls.py
@@ -11,6 +11,7 @@ from zango.api.platform.tasks.v1 import urls as tasks_v1_urls
 
 from .views import (
     AppDetailViewAPIV1,
+    AppStatusActionView,
     AppViewAPIV1,
     SAMLProviderDetailViewAPIV1,
     SAMLProvidersViewAPIV1,
@@ -29,6 +30,11 @@ urlpatterns = [
         r"^(?P<app_uuid>[\w-]+)/$",
         AppDetailViewAPIV1.as_view(),
         name="apps-apiv1-appdetailview",
+    ),
+    re_path(
+        r"^(?P<app_uuid>[\w-]+)/status/(?P<action>[\w-]+)/$",
+        AppStatusActionView.as_view(),
+        name="apps-apiv1-appstatusaction",
     ),
     re_path(
         r"^(?P<app_uuid>[\w-]+)/roles/$",

--- a/backend/src/zango/api/platform/tenancy/v1/views.py
+++ b/backend/src/zango/api/platform/tenancy/v1/views.py
@@ -25,7 +25,7 @@ from zango.core.api import (
 )
 from zango.core.api.utils import ZangoAPIPagination
 from zango.core.common_utils import set_app_schema_path
-from zango.core.permissions import IsPlatformUserAllowedApp
+from zango.core.permissions import IsPlatformUserAllowedApp, IsSuperAdminPlatformUser
 from zango.core.utils import (
     get_country_code_for_tenant,
     get_search_columns,
@@ -991,3 +991,42 @@ class SAMLProviderDetailViewAPIV1(ZangoGenericPlatformAPIView, TenantMixin):
             status_code = 500
 
         return get_api_response(success, result, status_code)
+
+
+class AppStatusActionView(ZangoGenericPlatformAPIView):
+    """Flip an app's operational status.
+
+    ``POST /api/v1/platform/apps/<app_uuid>/status/<action>/``
+    where ``action`` is one of ``suspend`` or ``unsuspend``.
+
+    Suspend blocks all HTTP traffic to the tenant (see
+    ``ZangoTenantMainMiddleware``'s suspend guard) and causes any Celery
+    task routed through ``zango_task_executor`` or ``codexec_executor``
+    to raise ``TenantSuspended``. Unsuspend restores the tenant to
+    ``deployed`` status; the next request succeeds normally.
+    """
+
+    permission_classes = (IsSuperAdminPlatformUser,)
+
+    _ALLOWED_ACTIONS = ("suspend", "unsuspend")
+
+    def post(self, request, app_uuid, action, *args, **kwargs):
+        if action not in self._ALLOWED_ACTIONS:
+            return get_api_response(
+                False,
+                {"message": f"Unknown action '{action}'."},
+                400,
+            )
+        try:
+            tenant = TenantModel.objects.get(uuid=app_uuid)
+        except TenantModel.DoesNotExist:
+            return get_api_response(
+                False, {"message": "App not found."}, 404
+            )
+        # `tenant.suspend()` / `tenant.unsuspend()` — one line each.
+        getattr(tenant, action)()
+        return get_api_response(
+            True,
+            {"tenant": TenantSerializerModel(tenant).data},
+            200,
+        )

--- a/backend/src/zango/apps/code_execution/tasks.py
+++ b/backend/src/zango/apps/code_execution/tasks.py
@@ -354,14 +354,6 @@ def codexec_executor(self, execution_uuid: str, tenant_name: str) -> dict:
     # 1. Bind tenant context
     tenant = TenantModel.objects.get(name=tenant_name)
     connection.set_tenant(tenant)
-    # Framework-level suspend guard. Codexec has its own Celery task
-    # that doesn't route through `zango_task_executor`, so the assertion
-    # is repeated here. Catches the case where a run was enqueued before
-    # the tenant was suspended and the flip happened while the task
-    # waited in the queue.
-    from zango.apps.shared.tenancy.utils import assert_tenant_active
-
-    assert_tenant_active(tenant)
 
     # 2. Load row + mark running
     try:
@@ -371,6 +363,41 @@ def codexec_executor(self, execution_uuid: str, tenant_name: str) -> dict:
     except CodeExecution.DoesNotExist:
         log.error("codexec: execution %s not found", execution_uuid)
         return {"status": "error", "reason": "execution_not_found"}
+
+    # 2b. Framework-level suspend guard. Codexec has its own Celery task
+    # that doesn't route through `zango_task_executor`, so the assertion
+    # is repeated here. Catches the case where a run was enqueued before
+    # the tenant was suspended and the flip happened while the task
+    # waited in the queue. Order matters: we load the execution row first
+    # so we can mark it ABORTED — otherwise the row stays at QUEUED
+    # forever and the UI never learns the run was skipped.
+    if getattr(tenant, "status", None) == "suspended":
+        log.info(
+            "codexec: skipping execution %s — tenant '%s' is suspended",
+            execution_uuid,
+            tenant.name,
+        )
+        execution.status = ExecStatus.ABORTED
+        execution.exception_type = "TenantSuspended"
+        execution.exception_message = (
+            f"Tenant '{tenant.name}' is suspended. Run was skipped without "
+            f"executing user code. Unsuspend the app and re-run to try again."
+        )
+        execution.ended_at = timezone.now()
+        execution.duration_ms = int(
+            (time.perf_counter() - started_perf) * 1000
+        )
+        execution.save(
+            update_fields=[
+                "status",
+                "exception_type",
+                "exception_message",
+                "ended_at",
+                "duration_ms",
+                "modified_at",
+            ]
+        )
+        return {"status": "skipped", "reason": "tenant_suspended"}
 
     execution.status = ExecStatus.RUNNING
     execution.started_at = started_at

--- a/backend/src/zango/apps/code_execution/tasks.py
+++ b/backend/src/zango/apps/code_execution/tasks.py
@@ -354,6 +354,14 @@ def codexec_executor(self, execution_uuid: str, tenant_name: str) -> dict:
     # 1. Bind tenant context
     tenant = TenantModel.objects.get(name=tenant_name)
     connection.set_tenant(tenant)
+    # Framework-level suspend guard. Codexec has its own Celery task
+    # that doesn't route through `zango_task_executor`, so the assertion
+    # is repeated here. Catches the case where a run was enqueued before
+    # the tenant was suspended and the flip happened while the task
+    # waited in the queue.
+    from zango.apps.shared.tenancy.utils import assert_tenant_active
+
+    assert_tenant_active(tenant)
 
     # 2. Load row + mark running
     try:

--- a/backend/src/zango/apps/shared/tenancy/models.py
+++ b/backend/src/zango/apps/shared/tenancy/models.py
@@ -150,43 +150,58 @@ class TenantModel(TenantMixin, FullAuditMixin):
         self._set_scheduled_tasks_enabled(True)
 
     def _set_scheduled_tasks_enabled(self, enabled: bool) -> None:
-        """Enable / disable every AppTask scheduled from the panel for
-        this tenant.
+        """Toggle every AppTask on/off exactly like the operator would from
+        the Async Tasks modal.
 
-        Each ``AppTask`` has a linked ``PeriodicTask`` (django-celery-beat).
-        Flipping ``PeriodicTask.enabled`` is what actually causes the beat
-        scheduler to stop firing the task; the ``AppTask.is_enabled`` flag
-        stays as the operator set it so we can restore intent on unsuspend.
-        Runs inside a ``schema_context`` because ``AppTask`` is a tenant
-        model.
+        Sets ``AppTask.is_enabled`` and calls ``save()`` — that path in
+        ``AppTask.save()`` already syncs ``PeriodicTask.enabled`` to
+        ``is_enabled``, so we get identical behaviour to a manual toggle.
+
+        On suspend we remember which task ids we disabled in
+        ``extra_config['tasks_disabled_by_suspend']`` so unsuspend only
+        re-enables tasks that were on before — tasks the operator had
+        deliberately turned off stay off.
         """
         # Local import: avoids a circular import at module load time.
         from django_tenants.utils import schema_context
 
         try:
-            with schema_context(self.schema_name):
-                from django_celery_beat.models import PeriodicTask
+            extra_config = self.extra_config or {}
+            if not enabled:
+                # Suspend: disable every AppTask that's currently on.
+                # Record what we touched so unsuspend can restore only
+                # those.
+                with schema_context(self.schema_name):
+                    from zango.apps.tasks.models import AppTask
 
-                from zango.apps.tasks.models import AppTask
-
-                if enabled:
-                    # Re-enable only the tasks the operator had marked
-                    # is_enabled=True before we touched them.
-                    task_ids = list(
+                    to_disable = list(
                         AppTask.objects.filter(is_enabled=True).values_list(
-                            "master_task_id", flat=True
+                            "id", flat=True
                         )
                     )
-                else:
-                    task_ids = list(
-                        AppTask.objects.exclude(master_task__isnull=True).values_list(
-                            "master_task_id", flat=True
-                        )
-                    )
-                if task_ids:
-                    PeriodicTask.objects.filter(id__in=task_ids).update(
-                        enabled=enabled
-                    )
+                    for app_task in AppTask.objects.filter(id__in=to_disable):
+                        app_task.is_enabled = False
+                        app_task.save()
+                if to_disable:
+                    extra_config["tasks_disabled_by_suspend"] = list(to_disable)
+                    self.extra_config = extra_config
+                    self.save(update_fields=["extra_config", "modified_at"])
+            else:
+                # Unsuspend: re-enable only the ids we disabled on suspend.
+                # If nothing was recorded (e.g. suspend predates this
+                # feature or extra_config was reset) we do nothing rather
+                # than turning on tasks the operator meant to leave off.
+                to_enable = extra_config.get("tasks_disabled_by_suspend") or []
+                if to_enable:
+                    with schema_context(self.schema_name):
+                        from zango.apps.tasks.models import AppTask
+
+                        for app_task in AppTask.objects.filter(id__in=to_enable):
+                            app_task.is_enabled = True
+                            app_task.save()
+                    extra_config.pop("tasks_disabled_by_suspend", None)
+                    self.extra_config = extra_config
+                    self.save(update_fields=["extra_config", "modified_at"])
         except Exception:
             # Never let scheduled-task cleanup abort the status change —
             # the middleware guard is the primary defence. Log and move on.

--- a/backend/src/zango/apps/shared/tenancy/models.py
+++ b/backend/src/zango/apps/shared/tenancy/models.py
@@ -131,17 +131,72 @@ class TenantModel(TenantMixin, FullAuditMixin):
         self.status = "suspended"
         self.suspended_on = timezone.now()
         self.save()
+        self._set_scheduled_tasks_enabled(False)
 
     def unsuspend(self):
         """Restore a suspended tenant to deployed status.
 
         Traffic resumes immediately on the next request; queued Celery
         tasks that were rejected while suspended are gone — they need to
-        be re-dispatched by the caller if desired.
+        be re-dispatched by the caller if desired. Panel-scheduled tasks
+        (AppTask) that were disabled by ``suspend()`` are re-enabled here,
+        but only ones the operator had marked ``is_enabled=True`` before
+        the suspension — we don't accidentally start tasks the user had
+        deliberately turned off.
         """
         self.status = "deployed"
         self.suspended_on = None
         self.save()
+        self._set_scheduled_tasks_enabled(True)
+
+    def _set_scheduled_tasks_enabled(self, enabled: bool) -> None:
+        """Enable / disable every AppTask scheduled from the panel for
+        this tenant.
+
+        Each ``AppTask`` has a linked ``PeriodicTask`` (django-celery-beat).
+        Flipping ``PeriodicTask.enabled`` is what actually causes the beat
+        scheduler to stop firing the task; the ``AppTask.is_enabled`` flag
+        stays as the operator set it so we can restore intent on unsuspend.
+        Runs inside a ``schema_context`` because ``AppTask`` is a tenant
+        model.
+        """
+        # Local import: avoids a circular import at module load time.
+        from django_tenants.utils import schema_context
+
+        try:
+            with schema_context(self.schema_name):
+                from django_celery_beat.models import PeriodicTask
+
+                from zango.apps.tasks.models import AppTask
+
+                if enabled:
+                    # Re-enable only the tasks the operator had marked
+                    # is_enabled=True before we touched them.
+                    task_ids = list(
+                        AppTask.objects.filter(is_enabled=True).values_list(
+                            "master_task_id", flat=True
+                        )
+                    )
+                else:
+                    task_ids = list(
+                        AppTask.objects.exclude(master_task__isnull=True).values_list(
+                            "master_task_id", flat=True
+                        )
+                    )
+                if task_ids:
+                    PeriodicTask.objects.filter(id__in=task_ids).update(
+                        enabled=enabled
+                    )
+        except Exception:
+            # Never let scheduled-task cleanup abort the status change —
+            # the middleware guard is the primary defence. Log and move on.
+            import logging
+
+            logging.getLogger(__name__).exception(
+                "Failed to %s scheduled tasks for tenant %s",
+                "enable" if enabled else "disable",
+                self.schema_name,
+            )
 
     @classmethod
     def create(

--- a/backend/src/zango/apps/shared/tenancy/models.py
+++ b/backend/src/zango/apps/shared/tenancy/models.py
@@ -132,6 +132,17 @@ class TenantModel(TenantMixin, FullAuditMixin):
         self.suspended_on = timezone.now()
         self.save()
 
+    def unsuspend(self):
+        """Restore a suspended tenant to deployed status.
+
+        Traffic resumes immediately on the next request; queued Celery
+        tasks that were rejected while suspended are gone — they need to
+        be re-dispatched by the caller if desired.
+        """
+        self.status = "deployed"
+        self.suspended_on = None
+        self.save()
+
     @classmethod
     def create(
         cls,

--- a/backend/src/zango/apps/shared/tenancy/templates/tenancy/app_suspended.html
+++ b/backend/src/zango/apps/shared/tenancy/templates/tenancy/app_suspended.html
@@ -1,0 +1,168 @@
+{% load static %}<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>App unavailable — {{ tenant.name }}</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:opsz,wght@14..32,400..700&family=Instrument+Serif:ital@0;1&family=JetBrains+Mono:wght@500&display=swap" rel="stylesheet">
+    <style>
+        :root {
+            --surface-page: #F6F7FB;
+            --surface-card: #FFFFFF;
+            --text-strong: #0B0D14;
+            --text-body: #2C3047;
+            --text-muted: #5A607A;
+            --text-subtle: #8389A3;
+            --border: #E3E6EF;
+            --border-soft: #ECEEF5;
+            --amber-50: #FEF6E7;
+            --amber-100: #FCEAC4;
+            --amber-500: #DA9011;
+            --amber-700: #8A5A07;
+            --amber-900: #5A3B04;
+            --indigo-500: #5961E5;
+            --shadow-amber: 0 8px 24px -6px rgba(218,144,17,.22), 0 2px 4px rgba(218,144,17,.08);
+            --shadow-md: 0 4px 12px -2px rgba(15,19,36,.08), 0 2px 4px rgba(15,19,36,.04), inset 0 1px 0 rgba(255,255,255,.6);
+        }
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        html, body { height: 100%; }
+        body {
+            font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+            font-feature-settings: 'cv11', 'ss01', 'ss03';
+            font-optical-sizing: auto;
+            -webkit-font-smoothing: antialiased;
+            background: var(--surface-page);
+            color: var(--text-body);
+            line-height: 1.55;
+            display: grid;
+            place-items: center;
+            padding: 32px 20px;
+        }
+        .suspended-page {
+            background: var(--surface-card);
+            border-radius: 16px;
+            padding: 64px 56px 44px;
+            max-width: 560px;
+            width: 100%;
+            text-align: center;
+            box-shadow: var(--shadow-md);
+            border: 1px solid var(--border);
+            position: relative;
+            overflow: hidden;
+            animation: fadeUp 460ms cubic-bezier(.22, 1, .36, 1) both;
+        }
+        .suspended-page::before {
+            content: '';
+            position: absolute;
+            top: 0; left: 0; right: 0;
+            height: 3px;
+            background: linear-gradient(90deg, var(--amber-500) 0%, var(--indigo-500) 100%);
+        }
+        .suspended-badge {
+            display: inline-flex;
+            align-items: center;
+            gap: 8px;
+            padding: 6px 14px;
+            border-radius: 999px;
+            background: var(--amber-50);
+            border: 1px solid var(--amber-100);
+            font-size: 11px;
+            letter-spacing: .09em;
+            text-transform: uppercase;
+            font-weight: 600;
+            color: var(--amber-700);
+            margin-bottom: 24px;
+        }
+        .suspended-badge::before {
+            content: '';
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--amber-500);
+            box-shadow: 0 0 0 3px rgba(218, 144, 17, .24);
+        }
+        .suspended-icon {
+            width: 72px;
+            height: 72px;
+            margin: 0 auto 22px;
+            border-radius: 20px;
+            background: linear-gradient(140deg, #FEF6E7 0%, #FCEAC4 100%);
+            border: 1px solid var(--amber-100);
+            display: grid;
+            place-items: center;
+            color: var(--amber-700);
+            box-shadow: var(--shadow-amber);
+        }
+        h1 {
+            font-size: 32px;
+            font-weight: 600;
+            letter-spacing: -0.028em;
+            line-height: 1.1;
+            color: var(--text-strong);
+            margin-bottom: 12px;
+        }
+        h1 em {
+            font-family: 'Instrument Serif', 'Times New Roman', serif;
+            font-style: italic;
+            font-weight: 400;
+            color: var(--amber-700);
+        }
+        .msg {
+            font-size: 14.5px;
+            color: var(--text-muted);
+            line-height: 1.6;
+            max-width: 42ch;
+            margin: 0 auto 24px;
+        }
+        .support-line {
+            font-size: 13px;
+            color: var(--text-body);
+            padding-top: 24px;
+            border-top: 1px solid var(--border-soft);
+        }
+        .support-line a {
+            color: var(--indigo-500);
+            font-weight: 500;
+            text-decoration: none;
+            border-bottom: 1px solid rgba(89, 97, 229, .3);
+        }
+        .support-line a:hover { border-bottom-color: var(--indigo-500); }
+        .meta {
+            margin-top: 24px;
+            padding-top: 20px;
+            border-top: 1px dashed var(--border);
+            font-size: 11.5px;
+            color: var(--text-subtle);
+            font-family: 'JetBrains Mono', 'SF Mono', Consolas, monospace;
+        }
+        @keyframes fadeUp {
+            from { opacity: 0; transform: translateY(8px); }
+            to { opacity: 1; transform: none; }
+        }
+        @media (prefers-reduced-motion: reduce) {
+            * { animation: none !important; }
+        }
+    </style>
+</head>
+<body>
+    <div class="suspended-page">
+        <div class="suspended-badge">App unavailable</div>
+        <div class="suspended-icon">
+            <svg width="34" height="34" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                <rect x="3" y="11" width="18" height="10" rx="2"/>
+                <path d="M7 11V7a5 5 0 0 1 10 0v4"/>
+            </svg>
+        </div>
+        <h1>This app is currently <em>suspended</em></h1>
+        <p class="msg">
+            Access to this application has been paused by the platform administrator. Your data is preserved and unchanged.
+        </p>
+        <p class="support-line">
+            Please contact <a href="mailto:{{ support_email }}">support</a> if you believe this is in error.
+        </p>
+        <div class="meta">Reference · {{ tenant.domain_url|default:tenant.name }} · 404</div>
+    </div>
+</body>
+</html>

--- a/backend/src/zango/apps/shared/tenancy/templates/tenancy/app_suspended.html
+++ b/backend/src/zango/apps/shared/tenancy/templates/tenancy/app_suspended.html
@@ -122,13 +122,6 @@
             padding-top: 24px;
             border-top: 1px solid var(--border-soft);
         }
-        .support-line a {
-            color: var(--indigo-500);
-            font-weight: 500;
-            text-decoration: none;
-            border-bottom: 1px solid rgba(89, 97, 229, .3);
-        }
-        .support-line a:hover { border-bottom-color: var(--indigo-500); }
         .meta {
             margin-top: 24px;
             padding-top: 20px;
@@ -160,7 +153,7 @@
             Access to this application has been paused by the platform administrator. Your data is preserved and unchanged.
         </p>
         <p class="support-line">
-            Please contact <a href="mailto:{{ support_email }}">support</a> if you believe this is in error.
+            Please contact support if you believe this is in error.
         </p>
         <div class="meta">Reference · {{ tenant.domain_url|default:tenant.name }} · 404</div>
     </div>

--- a/backend/src/zango/apps/shared/tenancy/utils.py
+++ b/backend/src/zango/apps/shared/tenancy/utils.py
@@ -1,13 +1,45 @@
 import pytz
 
+from django.db import connection
 from django_tenants.utils import schema_context
+from loguru import logger
 
 
 __all__ = [
     "TIMEZONES",
     "DATEFORMAT",
     "DATETIMEFORMAT",
+    "TenantSuspended",
+    "assert_tenant_active",
 ]
+
+
+class TenantSuspended(Exception):
+    """Raised when a Celery task is invoked against a suspended tenant.
+
+    Celery treats this as a task failure — the broker acknowledges the
+    message and the failure is recorded. A future dispatch after the
+    tenant is unsuspended runs normally.
+    """
+
+
+def assert_tenant_active(tenant=None):
+    """Raise ``TenantSuspended`` if the (given or current-connection) tenant
+    is suspended.
+
+    Cheap — one attribute lookup, no DB roundtrip. Called from
+    ``zango_task_executor`` and ``codexec_executor`` right after
+    ``connection.set_tenant(...)`` so the two chokepoints where every
+    tenant-scoped Celery task passes through catch a suspended tenant
+    before any workspace code loads.
+    """
+    tenant = tenant or getattr(connection, "tenant", None)
+    if tenant is not None and getattr(tenant, "status", None) == "suspended":
+        logger.info(
+            "Task skipped: tenant '{}' is suspended",
+            getattr(tenant, "schema_name", "?"),
+        )
+        raise TenantSuspended(getattr(tenant, "schema_name", "?"))
 
 TIMEZONES = [(tz, tz) for tz in pytz.all_timezones]
 

--- a/backend/src/zango/cli/update_apps.py
+++ b/backend/src/zango/cli/update_apps.py
@@ -616,11 +616,42 @@ def update_apps(app_name, pull):
 
     from zango.apps.shared.tenancy.models import TenantModel
 
-    tenants = TenantModel.objects.filter(status="deployed").exclude(
-        tenant_type="shared"
+    tenants = TenantModel.objects.exclude(tenant_type="shared")
+
+    # Suspended tenants are intentionally skipped by update-apps — an app
+    # in that state should not be touched (no migrations, no fixtures,
+    # no release rows) until an operator unsuspends it. Surface the skip
+    # loudly so runbook / CI logs record why a given tenant was omitted.
+    suspended_tenants = list(
+        tenants.filter(status="suspended").values_list("name", flat=True)
     )
+    if suspended_tenants:
+        click.echo(
+            click.style(
+                f"Skipping suspended tenant(s): {', '.join(suspended_tenants)}",
+                fg="yellow",
+                bold=True,
+            )
+        )
+
+    # Only deployed tenants proceed. Staged / deleted are excluded by the
+    # same rule the command already applied.
+    tenants = tenants.filter(status="deployed")
+
     if app_name:
         click.echo(f"Updating apps: {app_name}")
+        # If the operator explicitly asked for a suspended tenant by name,
+        # tell them why it's not in the result set instead of silently
+        # returning "no app found".
+        for requested in app_name:
+            if requested in suspended_tenants:
+                click.echo(
+                    click.style(
+                        f"'{requested}' is suspended — unsuspend it before running update-apps.",
+                        fg="yellow",
+                        bold=True,
+                    )
+                )
         tenants = tenants.filter(name__in=app_name)
         if not tenants.exists():
             error_message = click.style(

--- a/backend/src/zango/core/tasks.py
+++ b/backend/src/zango/core/tasks.py
@@ -11,11 +11,16 @@ def zango_task_executor(tenant_name, task_name, *args, timezone_name=None, **kwa
 
     from zango.apps.dynamic_models.workspace.base import Workspace
     from zango.apps.shared.tenancy.models import TenantModel
+    from zango.apps.shared.tenancy.utils import assert_tenant_active
     from zango.apps.tasks.models import AppTask
 
     tenant = TenantModel.objects.get(name=tenant_name)
 
     connection.set_tenant(tenant)
+    # Framework-level suspend guard — every workspace-scoped task routes
+    # through this wrapper, so one assertion covers HTTP-dispatched,
+    # beat-scheduled, chained, and retried tasks alike.
+    assert_tenant_active(tenant)
     with connection.cursor() as c:
         task_obj = AppTask.objects.get(name=task_name)
 

--- a/backend/src/zango/middleware/tenant.py
+++ b/backend/src/zango/middleware/tenant.py
@@ -26,10 +26,13 @@ from zango.core.utils import get_region_from_timezone
 # Paths that continue to work when a tenant is suspended. Two categories
 # matter: (a) health checks, so load balancers don't mark the app as
 # unhealthy; (b) the platform-admin API, so operators can unsuspend from
-# the admin UI.
+# the admin UI. The platform apps API lives at /api/v1/apps/ (mounted by
+# `zango.api.platform.urls` under `urls_public.py`), not at
+# /api/v1/platform/apps/ — matching the real URL structure here.
 _SUSPEND_EXEMPT_PATH_PREFIXES = (
     "/api/v1/health/",
-    "/api/v1/platform/",
+    "/api/v1/apps/",
+    "/platform/",
 )
 
 

--- a/backend/src/zango/middleware/tenant.py
+++ b/backend/src/zango/middleware/tenant.py
@@ -122,12 +122,7 @@ class ZangoTenantMainMiddleware(TenantMainMiddleware):
             return render(
                 request,
                 "tenancy/app_suspended.html",
-                {
-                    "tenant": tenant,
-                    "support_email": getattr(
-                        settings, "SUPPORT_EMAIL", "support@zango.dev"
-                    ),
-                },
+                {"tenant": tenant},
                 status=404,
             )
 

--- a/backend/src/zango/middleware/tenant.py
+++ b/backend/src/zango/middleware/tenant.py
@@ -15,11 +15,22 @@ from django.conf import settings
 from django.core.exceptions import DisallowedHost
 from django.db import connection
 from django.http import Http404
+from django.shortcuts import render
 from django.urls import set_urlconf
 from django.utils import timezone
 from django.utils.deprecation import MiddlewareMixin
 
 from zango.core.utils import get_region_from_timezone
+
+
+# Paths that continue to work when a tenant is suspended. Two categories
+# matter: (a) health checks, so load balancers don't mark the app as
+# unhealthy; (b) the platform-admin API, so operators can unsuspend from
+# the admin UI.
+_SUSPEND_EXEMPT_PATH_PREFIXES = (
+    "/api/v1/health/",
+    "/api/v1/platform/",
+)
 
 
 class ZangoTenantMainMiddleware(TenantMainMiddleware):
@@ -97,9 +108,37 @@ class ZangoTenantMainMiddleware(TenantMainMiddleware):
         request.tenant = tenant
         request.internal_routing = False
         connection.set_tenant(request.tenant)
+
+        # Suspend guard — short-circuit any request to a suspended tenant.
+        # Health check + platform-admin routes are exempt so the load
+        # balancer stays green and operators can still unsuspend.
+        if (
+            getattr(tenant, "status", None) == "suspended"
+            and not self._is_suspend_exempt(request)
+        ):
+            return render(
+                request,
+                "tenancy/app_suspended.html",
+                {
+                    "tenant": tenant,
+                    "support_email": getattr(
+                        settings, "SUPPORT_EMAIL", "support@zango.dev"
+                    ),
+                },
+                status=404,
+            )
+
         self.setup_url_routing(request)
 
         return self.get_response(request)
+
+    @staticmethod
+    def _is_suspend_exempt(request):
+        """Whether this request bypasses the suspend guard."""
+        return any(
+            request.path.startswith(prefix)
+            for prefix in _SUSPEND_EXEMPT_PATH_PREFIXES
+        )
 
     def no_tenant_found(self, request, hostname):
         """

--- a/frontend/src/pages/app/components/SideMenu/index.jsx
+++ b/frontend/src/pages/app/components/SideMenu/index.jsx
@@ -1,16 +1,54 @@
 import { NavLink } from 'react-router-dom';
+import { useSelector } from 'react-redux';
 import { ReactComponent as AppSettingsIcon } from '../../../../assets/images/svg/app-settings-icon.svg';
 import { ReactComponent as AppUserManagementIcon } from '../../../../assets/images/svg/app-user-management-icon.svg';
 import { ReactComponent as AppSecretsIcon } from '../../../../assets/images/svg/app-secrets-icon.svg';
 import { ReactComponent as DashboardIcon } from '../../../../assets/images/svg/app-settings-icon.svg';
+import { selectAppConfigurationData } from '../../../appConfiguration/slice';
 
 export default function SideMenu() {
+	const appConfigurationData = useSelector(selectAppConfigurationData);
+	const isSuspended =
+		(appConfigurationData?.app?.status ||
+			appConfigurationData?.status) === 'suspended';
+
 	return (
 		<div
 			data-cy="menu_section"
-			className="z-[3] w-[88px] min-w-[88px] max-w-[88px] bg-secondary pt-[12px] sticky top-0 overflow-y-auto"
+			className="z-[3] flex w-[88px] min-w-[88px] max-w-[88px] flex-col bg-secondary pt-[12px] sticky top-0 overflow-y-auto"
 			style={{ height: 'calc(100vh - var(--navHeight, 64px))' }}
 		>
+			{isSuspended ? (
+				<div
+					className="mx-[8px] mb-[10px] flex flex-col items-center gap-[4px] rounded-[8px] border px-[4px] py-[8px]"
+					style={{
+						backgroundColor: '#FEF6E7',
+						borderColor: 'rgba(218,144,17,0.32)',
+					}}
+					title="This app is suspended — end users see a 404 page"
+					data-cy="app_suspended_badge"
+				>
+					<svg
+						width="16"
+						height="16"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="#8A5A07"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					>
+						<rect x="3" y="11" width="18" height="10" rx="2" />
+						<path d="M7 11V7a5 5 0 0 1 10 0v4" />
+					</svg>
+					<span
+						className="text-center font-lato text-[9px] font-bold uppercase leading-[11px] tracking-[0.06em]"
+						style={{ color: '#8A5A07' }}
+					>
+						Suspended
+					</span>
+				</div>
+			) : null}
 			<NavLink
 				data-cy="app_settings"
 				to={`app-settings/app-configuration/`}

--- a/frontend/src/pages/appCode/components/AsyncTasks/index.jsx
+++ b/frontend/src/pages/appCode/components/AsyncTasks/index.jsx
@@ -88,9 +88,13 @@ export default function AsyncTasks() {
 		}));
 	};
 
-	// Get status badge
-	const getStatusBadge = (isEnabled) => {
-		if (isEnabled) {
+	// Get status badge from is_enabled — when the app is suspended,
+	// AppTask.is_enabled is flipped to False by the tenant suspend logic
+	// (same effect as the operator toggling it Disabled in this modal),
+	// so this single field is the source of truth. On unsuspend, the ids
+	// we flipped are restored to True.
+	const getStatusBadge = (task) => {
+		if (task?.is_enabled) {
 			return (
 				<span className="inline-flex items-center gap-1 px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">
 					<span className="w-1.5 h-1.5 bg-green-600 rounded-full"></span>
@@ -412,7 +416,7 @@ export default function AsyncTasks() {
 														</div>
 													</td>
 													<td className="px-6 py-4 whitespace-nowrap">
-														{getStatusBadge(task.is_enabled)}
+														{getStatusBadge(task)}
 													</td>
 													<td className="px-6 py-4 whitespace-nowrap">
 														<code className="text-xs font-mono bg-gray-100 px-2 py-1 rounded">

--- a/frontend/src/pages/appCode/components/CodeExecution/ExecutionDetail.jsx
+++ b/frontend/src/pages/appCode/components/CodeExecution/ExecutionDetail.jsx
@@ -605,6 +605,45 @@ export default function ExecutionDetail({ appId, executionId, onBack, onEditSnip
 								</div>
 							)}
 						</div>
+						{(execution.exception_type || execution.exception_message) && (
+							(() => {
+								const isSuspended = execution.exception_type === 'TenantSuspended';
+								const palette = isSuspended
+									? {
+											labelColor: 'text-amber-800',
+											boxBg: 'bg-amber-50',
+											boxBorder: 'border-amber-200',
+											boxText: 'text-amber-900',
+											label: 'App suspended',
+									  }
+									: {
+											labelColor: 'text-rose-700',
+											boxBg: 'bg-rose-50',
+											boxBorder: 'border-rose-200',
+											boxText: 'text-rose-800',
+											label: 'Reason',
+									  };
+								return (
+									<>
+										<div className={`mt-4 mb-2 text-[12px] font-semibold ${palette.labelColor}`}>
+											{palette.label}
+										</div>
+										<div className={`${palette.boxBg} border ${palette.boxBorder} rounded-md p-3.5 text-[12px] ${palette.boxText}`}>
+											{execution.exception_type && (
+												<div className="font-mono text-[11px] font-semibold mb-1.5">
+													{execution.exception_type}
+												</div>
+											)}
+											{execution.exception_message && (
+												<div className="whitespace-pre-wrap">
+													{execution.exception_message}
+												</div>
+											)}
+										</div>
+									</>
+								);
+							})()
+						)}
 						{execution.exception_traceback && (
 							<>
 								<div className="mt-4 mb-2 text-[12px] font-semibold text-rose-700">Traceback</div>
@@ -806,6 +845,12 @@ export default function ExecutionDetail({ appId, executionId, onBack, onEditSnip
 						<div className="text-slate-500">Duration</div><div className="text-slate-900 font-mono">{formatDuration(execution.duration_ms)}</div>
 						<div className="text-slate-500">Celery task</div><div className="text-slate-900 font-mono break-all">{execution.celery_task_id || '—'}</div>
 						<div className="text-slate-500">Exception</div><div className="text-slate-900 font-mono">{execution.exception_type || '—'}</div>
+						{execution.exception_message ? (
+							<>
+								<div className="text-slate-500">Message</div>
+								<div className="text-slate-900 whitespace-pre-wrap">{execution.exception_message}</div>
+							</>
+						) : null}
 					</div>
 				)}
 			</div>

--- a/frontend/src/pages/appConfiguration/components/UnifiedAppSettings/index.jsx
+++ b/frontend/src/pages/appConfiguration/components/UnifiedAppSettings/index.jsx
@@ -173,9 +173,34 @@ export default function UnifiedAppSettings() {
 								</svg>
 							</div>
 							<div>
-								<h1 className="font-source-sans-pro text-[24px] font-semibold leading-[32px] text-[#111827]">
-									App Settings
-								</h1>
+								<div className="flex items-center gap-[10px]">
+									<h1 className="font-source-sans-pro text-[24px] font-semibold leading-[32px] text-[#111827]">
+										App Settings
+									</h1>
+									{appConfigurationData?.status === 'suspended' ? (
+										<span
+											className="inline-flex items-center gap-[6px] rounded-full border px-[9px] py-[3px] font-lato text-[10.5px] font-bold uppercase leading-[14px] tracking-[0.08em]"
+											style={{
+												backgroundColor: '#FEF6E7',
+												borderColor: 'rgba(218,144,17,0.28)',
+												color: '#8A5A07',
+											}}
+											title="This app is suspended — end users see a 404 page"
+										>
+											<span
+												aria-hidden
+												style={{
+													width: 6,
+													height: 6,
+													borderRadius: 999,
+													backgroundColor: '#DA9011',
+													boxShadow: '0 0 0 2px rgba(218,144,17,0.22)',
+												}}
+											/>
+											Suspended
+										</span>
+									) : null}
+								</div>
 								<p className="font-lato text-[14px] leading-[20px] text-[#6B7280]">
 									Manage your application configuration, authentication, and themes
 								</p>

--- a/frontend/src/pages/appConfiguration/components/UnifiedAppSettings/index.jsx
+++ b/frontend/src/pages/appConfiguration/components/UnifiedAppSettings/index.jsx
@@ -177,7 +177,8 @@ export default function UnifiedAppSettings() {
 									<h1 className="font-source-sans-pro text-[24px] font-semibold leading-[32px] text-[#111827]">
 										App Settings
 									</h1>
-									{appConfigurationData?.status === 'suspended' ? (
+									{(appConfigurationData?.app?.status ||
+										appConfigurationData?.status) === 'suspended' ? (
 										<span
 											className="inline-flex items-center gap-[6px] rounded-full border px-[9px] py-[3px] font-lato text-[10.5px] font-bold uppercase leading-[14px] tracking-[0.08em]"
 											style={{

--- a/frontend/src/pages/appTaskManagement/components/AppTable/columns.jsx
+++ b/frontend/src/pages/appTaskManagement/components/AppTable/columns.jsx
@@ -96,7 +96,7 @@ function columns({ debounceSearch, localTableData }) {
 				</div>
 			),
 		}),
-		columnHelper.accessor((row) => row.is_enabled, {
+		columnHelper.accessor((row) => row, {
 			id: 'is_enabled',
 			header: () => (
 				<div className="flex h-full items-start justify-start gap-[16px] border-b-[4px] border-[#F0F3F4] px-[20px] py-[12px] text-start">
@@ -137,17 +137,42 @@ function columns({ debounceSearch, localTableData }) {
 					</div>
 				</div>
 			),
-			cell: (info) => (
-				<div className="flex h-full flex-col border-b border-[#F0F3F4] px-[20px] py-[14px]">
-					<span
-						className={`w-fit min-w-[77px] rounded-[15px] px-[4px] py-[3px] text-center font-lato text-[12px] font-normal capitalize leading-[16px] tracking-[0.2px] text-[#1C1E27] ${
-							info.getValue() ? 'bg-[#E4F9F2]' : 'bg-[#FBE0DD]'
-						}`}
-					>
-						{info.getValue() ? 'Scheduled' : 'Disabled'}
-					</span>
-				</div>
-			),
+			cell: (info) => {
+				const row = info.getValue() || {};
+				const isEnabled = row.is_enabled;
+				const runtimeEnabled = row.runtime_enabled;
+				// Three visible states:
+				//  - Scheduled: is_enabled=true AND runtime_enabled=true
+				//  - Paused: is_enabled=true BUT runtime_enabled=false (tenant suspended)
+				//  - Disabled: is_enabled=false (operator turned it off)
+				let label;
+				let className;
+				let title;
+				if (!isEnabled) {
+					label = 'Disabled';
+					className = 'bg-[#FBE0DD]';
+					title = 'Task is disabled — operator turned it off';
+				} else if (runtimeEnabled === false) {
+					label = 'Paused';
+					className = 'bg-[#FEF6E7]';
+					title =
+						'Task is paused because the app is suspended — will resume on unsuspend';
+				} else {
+					label = 'Scheduled';
+					className = 'bg-[#E4F9F2]';
+					title = 'Task is scheduled — beat will fire on the cron';
+				}
+				return (
+					<div className="flex h-full flex-col border-b border-[#F0F3F4] px-[20px] py-[14px]">
+						<span
+							title={title}
+							className={`w-fit min-w-[77px] rounded-[15px] px-[4px] py-[3px] text-center font-lato text-[12px] font-normal capitalize leading-[16px] tracking-[0.2px] text-[#1C1E27] ${className}`}
+						>
+							{label}
+						</span>
+					</div>
+				);
+			},
 		}),
 	];
 

--- a/frontend/src/pages/appTaskManagement/components/AppTable/columns.jsx
+++ b/frontend/src/pages/appTaskManagement/components/AppTable/columns.jsx
@@ -96,7 +96,7 @@ function columns({ debounceSearch, localTableData }) {
 				</div>
 			),
 		}),
-		columnHelper.accessor((row) => row, {
+		columnHelper.accessor((row) => row.is_enabled, {
 			id: 'is_enabled',
 			header: () => (
 				<div className="flex h-full items-start justify-start gap-[16px] border-b-[4px] border-[#F0F3F4] px-[20px] py-[12px] text-start">
@@ -137,42 +137,17 @@ function columns({ debounceSearch, localTableData }) {
 					</div>
 				</div>
 			),
-			cell: (info) => {
-				const row = info.getValue() || {};
-				const isEnabled = row.is_enabled;
-				const runtimeEnabled = row.runtime_enabled;
-				// Three visible states:
-				//  - Scheduled: is_enabled=true AND runtime_enabled=true
-				//  - Paused: is_enabled=true BUT runtime_enabled=false (tenant suspended)
-				//  - Disabled: is_enabled=false (operator turned it off)
-				let label;
-				let className;
-				let title;
-				if (!isEnabled) {
-					label = 'Disabled';
-					className = 'bg-[#FBE0DD]';
-					title = 'Task is disabled — operator turned it off';
-				} else if (runtimeEnabled === false) {
-					label = 'Paused';
-					className = 'bg-[#FEF6E7]';
-					title =
-						'Task is paused because the app is suspended — will resume on unsuspend';
-				} else {
-					label = 'Scheduled';
-					className = 'bg-[#E4F9F2]';
-					title = 'Task is scheduled — beat will fire on the cron';
-				}
-				return (
-					<div className="flex h-full flex-col border-b border-[#F0F3F4] px-[20px] py-[14px]">
-						<span
-							title={title}
-							className={`w-fit min-w-[77px] rounded-[15px] px-[4px] py-[3px] text-center font-lato text-[12px] font-normal capitalize leading-[16px] tracking-[0.2px] text-[#1C1E27] ${className}`}
-						>
-							{label}
-						</span>
-					</div>
-				);
-			},
+			cell: (info) => (
+				<div className="flex h-full flex-col border-b border-[#F0F3F4] px-[20px] py-[14px]">
+					<span
+						className={`w-fit min-w-[77px] rounded-[15px] px-[4px] py-[3px] text-center font-lato text-[12px] font-normal capitalize leading-[16px] tracking-[0.2px] text-[#1C1E27] ${
+							info.getValue() ? 'bg-[#E4F9F2]' : 'bg-[#FBE0DD]'
+						}`}
+					>
+						{info.getValue() ? 'Scheduled' : 'Disabled'}
+					</span>
+				</div>
+			),
 		}),
 	];
 

--- a/frontend/src/pages/platform/components/Platform/Apps/EachApp/StatusActionMenu.jsx
+++ b/frontend/src/pages/platform/components/Platform/Apps/EachApp/StatusActionMenu.jsx
@@ -46,7 +46,7 @@ export default function StatusActionMenu({ app, onStatusChanged }) {
 		if (busy) return;
 		setBusy(true);
 		const { success, response } = await triggerApi({
-			url: `/api/v1/platform/apps/${app.uuid}/status/unsuspend/`,
+			url: `/api/v1/apps/${app.uuid}/status/unsuspend/`,
 			type: 'POST',
 			loader: false,
 			showErrorModal: false,

--- a/frontend/src/pages/platform/components/Platform/Apps/EachApp/StatusActionMenu.jsx
+++ b/frontend/src/pages/platform/components/Platform/Apps/EachApp/StatusActionMenu.jsx
@@ -1,0 +1,150 @@
+import { useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+import useApi from '../../../../../../hooks/useApi';
+import SuspendAppDialog from './SuspendAppDialog';
+
+/**
+ * StatusActionMenu — kebab menu floated onto each app card.
+ *
+ * Placed at the card's top-right corner. Clicking the kebab stops
+ * propagation so the underlying <Link> doesn't navigate. Menu contents
+ * are dependent on the current status:
+ *   - deployed → "Suspend app" (opens type-to-confirm dialog)
+ *   - suspended → "Unsuspend app" (fires immediately — resuming is low-risk)
+ */
+export default function StatusActionMenu({ app, onStatusChanged }) {
+	const triggerApi = useApi();
+	const [open, setOpen] = useState(false);
+	const [dialogOpen, setDialogOpen] = useState(false);
+	const [busy, setBusy] = useState(false);
+	const menuRef = useRef(null);
+
+	// Close on outside click.
+	useEffect(() => {
+		if (!open) return undefined;
+		const onDoc = (e) => {
+			if (menuRef.current && !menuRef.current.contains(e.target)) setOpen(false);
+		};
+		document.addEventListener('mousedown', onDoc);
+		return () => document.removeEventListener('mousedown', onDoc);
+	}, [open]);
+
+	const stop = (e) => {
+		e.preventDefault();
+		e.stopPropagation();
+	};
+
+	const openSuspend = (e) => {
+		stop(e);
+		setOpen(false);
+		setDialogOpen(true);
+	};
+
+	const handleUnsuspend = async (e) => {
+		stop(e);
+		setOpen(false);
+		if (busy) return;
+		setBusy(true);
+		const { success, response } = await triggerApi({
+			url: `/api/v1/platform/apps/${app.uuid}/status/unsuspend/`,
+			type: 'POST',
+			loader: false,
+			showErrorModal: false,
+		});
+		setBusy(false);
+		if (success) {
+			toast.success(`Unsuspended "${app.name}"`);
+			onStatusChanged?.(response?.tenant);
+		} else {
+			toast.error(response?.message || 'Failed to unsuspend app');
+		}
+	};
+
+	const isSuspended = app.status === 'suspended';
+
+	return (
+		<>
+			<div
+				ref={menuRef}
+				className="absolute right-[10px] top-[10px] z-[2]"
+				onClick={stop}
+			>
+				<button
+					type="button"
+					aria-label="App actions"
+					onClick={(e) => {
+						stop(e);
+						setOpen((v) => !v);
+					}}
+					className="grid h-[28px] w-[28px] place-items-center rounded-[6px] border border-transparent bg-white/70 backdrop-blur-sm text-[#5A607A] transition-colors hover:border-[#DDE2E5] hover:bg-white hover:text-[#0B0D14]"
+				>
+					<svg
+						width="14"
+						height="14"
+						viewBox="0 0 24 24"
+						fill="currentColor"
+					>
+						<circle cx="5" cy="12" r="1.6" />
+						<circle cx="12" cy="12" r="1.6" />
+						<circle cx="19" cy="12" r="1.6" />
+					</svg>
+				</button>
+				{open && (
+					<div className="absolute right-0 top-[32px] min-w-[176px] rounded-[8px] border border-[#DDE2E5] bg-white py-[4px] shadow-[0_8px_24px_-8px_rgba(15,19,36,0.18)]">
+						{isSuspended ? (
+							<button
+								type="button"
+								onClick={handleUnsuspend}
+								disabled={busy}
+								className="flex w-full items-center gap-[10px] px-[12px] py-[8px] font-lato text-[13px] text-[#3938B5] transition-colors hover:bg-[#EEF1FE] disabled:cursor-not-allowed disabled:opacity-40"
+							>
+								<svg
+									width="14"
+									height="14"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								>
+									<polygon points="5 3 19 12 5 21 5 3" />
+								</svg>
+								Unsuspend app
+							</button>
+						) : (
+							<button
+								type="button"
+								onClick={openSuspend}
+								className="flex w-full items-center gap-[10px] px-[12px] py-[8px] font-lato text-[13px] text-[#8A5A07] transition-colors hover:bg-[#FEF6E7]"
+							>
+								<svg
+									width="14"
+									height="14"
+									viewBox="0 0 24 24"
+									fill="none"
+									stroke="currentColor"
+									strokeWidth="2"
+									strokeLinecap="round"
+									strokeLinejoin="round"
+								>
+									<rect x="6" y="4" width="4" height="16" />
+									<rect x="14" y="4" width="4" height="16" />
+								</svg>
+								Suspend app
+							</button>
+						)}
+					</div>
+				)}
+			</div>
+
+			{dialogOpen && (
+				<SuspendAppDialog
+					app={app}
+					onClose={() => setDialogOpen(false)}
+					onSuspended={onStatusChanged}
+				/>
+			)}
+		</>
+	);
+}

--- a/frontend/src/pages/platform/components/Platform/Apps/EachApp/StatusPill.jsx
+++ b/frontend/src/pages/platform/components/Platform/Apps/EachApp/StatusPill.jsx
@@ -1,0 +1,64 @@
+/**
+ * StatusPill — small colored badge for a tenant's operational status.
+ *
+ * `deployed` → sage/green (running normally)
+ * `suspended` → amber (blocked, but reversible)
+ * `staged`, `deleted`, everything else → slate (informational fallback)
+ */
+const VARIANTS = {
+	deployed: {
+		label: 'Active',
+		bg: '#EFF7EE',
+		border: 'rgba(90,164,91,0.28)',
+		dot: '#5AA45B',
+		text: '#36713A',
+	},
+	suspended: {
+		label: 'Suspended',
+		bg: '#FEF6E7',
+		border: 'rgba(218,144,17,0.28)',
+		dot: '#DA9011',
+		text: '#8A5A07',
+	},
+	staged: {
+		label: 'Staged',
+		bg: '#F4F5F8',
+		border: 'rgba(110,116,141,0.28)',
+		dot: '#6E748D',
+		text: '#3D4159',
+	},
+	deleted: {
+		label: 'Deleted',
+		bg: '#F4F5F8',
+		border: 'rgba(110,116,141,0.28)',
+		dot: '#6E748D',
+		text: '#3D4159',
+	},
+};
+
+export default function StatusPill({ status }) {
+	const v = VARIANTS[status] || VARIANTS.staged;
+	return (
+		<span
+			className="inline-flex items-center gap-[6px] rounded-full border px-[8px] py-[2px] font-lato text-[10px] font-bold uppercase leading-[14px] tracking-[0.06em]"
+			style={{
+				backgroundColor: v.bg,
+				borderColor: v.border,
+				color: v.text,
+			}}
+		>
+			<span
+				aria-hidden
+				style={{
+					display: 'inline-block',
+					width: 6,
+					height: 6,
+					borderRadius: 999,
+					backgroundColor: v.dot,
+					boxShadow: `0 0 0 2px ${v.dot}22`,
+				}}
+			/>
+			{v.label}
+		</span>
+	);
+}

--- a/frontend/src/pages/platform/components/Platform/Apps/EachApp/SuspendAppDialog.jsx
+++ b/frontend/src/pages/platform/components/Platform/Apps/EachApp/SuspendAppDialog.jsx
@@ -1,0 +1,141 @@
+import { useEffect, useRef, useState } from 'react';
+import toast from 'react-hot-toast';
+import useApi from '../../../../../../hooks/useApi';
+
+/**
+ * SuspendAppDialog — type-to-confirm modal.
+ *
+ * Requires the operator to type the app name exactly before the Suspend
+ * button enables — same pattern GitHub uses for destructive repo actions.
+ * The 2s of extra friction essentially eliminates accidental suspensions.
+ *
+ * Data preservation is stated inline so anxious admins don't panic.
+ */
+export default function SuspendAppDialog({ app, onClose, onSuspended }) {
+	const triggerApi = useApi();
+	const [typedName, setTypedName] = useState('');
+	const [busy, setBusy] = useState(false);
+	const inputRef = useRef(null);
+
+	const matches = typedName.trim() === app?.name;
+
+	useEffect(() => {
+		// Focus the input on mount so the operator can type immediately.
+		inputRef.current?.focus();
+	}, []);
+
+	useEffect(() => {
+		const onKey = (e) => {
+			if (e.key === 'Escape') onClose();
+		};
+		window.addEventListener('keydown', onKey);
+		return () => window.removeEventListener('keydown', onKey);
+	}, [onClose]);
+
+	const handleSuspend = async () => {
+		if (!matches || busy) return;
+		setBusy(true);
+		const { success, response } = await triggerApi({
+			url: `/api/v1/platform/apps/${app.uuid}/status/suspend/`,
+			type: 'POST',
+			loader: false,
+			showErrorModal: false,
+		});
+		setBusy(false);
+		if (success) {
+			toast.success(`Suspended "${app.name}"`);
+			onSuspended?.(response?.tenant);
+			onClose();
+		} else {
+			toast.error(response?.message || 'Failed to suspend app');
+		}
+	};
+
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center px-[16px]"
+			style={{ backgroundColor: 'rgba(15,19,36,0.42)' }}
+			onClick={onClose}
+			role="dialog"
+			aria-modal="true"
+		>
+			<div
+				className="w-full max-w-[460px] rounded-[14px] bg-white p-[28px] shadow-[0_20px_60px_-16px_rgba(15,19,36,0.35)]"
+				onClick={(e) => e.stopPropagation()}
+			>
+				{/* Icon */}
+				<div
+					className="mb-[16px] grid h-[44px] w-[44px] place-items-center rounded-[10px] border"
+					style={{
+						backgroundColor: '#FEF6E7',
+						borderColor: 'rgba(218,144,17,0.28)',
+						color: '#8A5A07',
+					}}
+				>
+					<svg
+						width="20"
+						height="20"
+						viewBox="0 0 24 24"
+						fill="none"
+						stroke="currentColor"
+						strokeWidth="2"
+						strokeLinecap="round"
+						strokeLinejoin="round"
+					>
+						<path d="M10.29 3.86L1.82 18a2 2 0 0 0 1.71 3h16.94a2 2 0 0 0 1.71-3L13.71 3.86a2 2 0 0 0-3.42 0z" />
+						<line x1="12" y1="9" x2="12" y2="13" />
+						<line x1="12" y1="17" x2="12.01" y2="17" />
+					</svg>
+				</div>
+
+				<h2
+					className="font-source-sans-pro text-[18px] font-semibold text-[#0B0D14]"
+					style={{ letterSpacing: '-0.012em' }}
+				>
+					Suspend "{app.name}"?
+				</h2>
+				<p className="mt-[6px] font-lato text-[13px] leading-[1.55] text-[#5A607A]">
+					All traffic to <strong className="text-[#0B0D14]">{app.domain_url || app.name}</strong>{' '}
+					will be blocked with a support-contact message. Panel-scheduled tasks will pause. Your data
+					is preserved and can be restored anytime by unsuspending.
+				</p>
+
+				<label className="mt-[18px] block">
+					<span className="mb-[6px] block font-lato text-[10.5px] font-semibold uppercase tracking-[0.06em] text-[#8389A3]">
+						Type the app name to confirm
+					</span>
+					<input
+						ref={inputRef}
+						type="text"
+						value={typedName}
+						onChange={(e) => setTypedName(e.target.value)}
+						placeholder={app.name}
+						className="w-full rounded-[8px] border border-[#D4D8E5] bg-[#F0F2F7] px-[12px] py-[8px] font-mono text-[13px] text-[#2C3047] outline-none transition-colors focus:border-[#5961E5] focus:bg-white"
+					/>
+				</label>
+
+				<div className="mt-[20px] flex justify-end gap-[10px]">
+					<button
+						type="button"
+						onClick={onClose}
+						className="rounded-[8px] border border-[#D4D8E5] bg-white px-[16px] py-[8px] font-lato text-[13px] font-medium text-[#2C3047] transition-colors hover:bg-[#F0F2F7]"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={handleSuspend}
+						disabled={!matches || busy}
+						className="rounded-[8px] px-[16px] py-[8px] font-lato text-[13px] font-medium text-white transition-opacity disabled:cursor-not-allowed disabled:opacity-40"
+						style={{
+							backgroundColor: '#DA9011',
+							boxShadow: '0 2px 6px -1px rgba(218,144,17,0.4)',
+						}}
+					>
+						{busy ? 'Suspending…' : 'Suspend app'}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}

--- a/frontend/src/pages/platform/components/Platform/Apps/EachApp/SuspendAppDialog.jsx
+++ b/frontend/src/pages/platform/components/Platform/Apps/EachApp/SuspendAppDialog.jsx
@@ -36,7 +36,7 @@ export default function SuspendAppDialog({ app, onClose, onSuspended }) {
 		if (!matches || busy) return;
 		setBusy(true);
 		const { success, response } = await triggerApi({
-			url: `/api/v1/platform/apps/${app.uuid}/status/suspend/`,
+			url: `/api/v1/apps/${app.uuid}/status/suspend/`,
 			type: 'POST',
 			loader: false,
 			showErrorModal: false,

--- a/frontend/src/pages/platform/components/Platform/Apps/EachApp/index.jsx
+++ b/frontend/src/pages/platform/components/Platform/Apps/EachApp/index.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { useDispatch } from 'react-redux';
 import { ReactComponent as EachAppIcon } from '../../../../../../assets/images/svg/each-app-icon.svg';
 import { ReactComponent as EachAppRocketIcon } from '../../../../../../assets/images/svg/each-app-rocket-icon.svg';
 import {
@@ -6,68 +7,122 @@ import {
 	getTimeFromNow,
 	isRecentlyLaunched,
 } from '../../../../../../utils/formats';
+import { toggleRerenderPage } from '../../../../slice';
 import AppLinkButton from './AppLinkButton';
+import StatusActionMenu from './StatusActionMenu';
+import StatusPill from './StatusPill';
 
 export default function EachApp({ data }) {
-	const { uuid, name, domain_url, description, logo, created_at, modified_at, last_released_version } =
-		data;
+	const dispatch = useDispatch();
+	const {
+		uuid,
+		name,
+		status,
+		domain_url,
+		description,
+		logo,
+		created_at,
+		modified_at,
+		last_released_version,
+	} = data;
+
+	const isSuspended = status === 'suspended';
+
+	// After a status change we trigger a rerender of the Platform page
+	// (see `Platform/index.jsx`), which re-fetches /api/v1/apps/ and
+	// updates every card at once — cheaper than optimistic local edits
+	// and it keeps `last_released_version` etc. in sync.
+	const refreshApps = () => dispatch(toggleRerenderPage());
 
 	return (
-		<Link
-			to={`${uuid}/app-settings/app-configuration/`}
-			className="group relative flex w-full flex-col rounded-[8px] border border-[#DDE2E5] hover:border-[#8485F6] hover:shadow-eachApp"
-		>
-			<div className="relative flex flex-col border-b border-[#F0F3F4] px-[16px] py-[22px]">
-				{logo ? (
-					<img
-						src={logo}
-						alt="#"
-						className="max-h-[32px] min-h-[32px] w-fit object-contain"
-					/>
-				) : (
-					<EachAppIcon className="mt-[6px] min-h-[32px] min-w-[32px]" />
-				)}
+		<div className="relative">
+			<StatusActionMenu app={data} onStatusChanged={refreshApps} />
+			<Link
+				to={`${uuid}/app-settings/app-configuration/`}
+				className={`group relative flex w-full flex-col rounded-[8px] border transition-colors ${
+					isSuspended
+						? 'border-[rgba(218,144,17,0.3)] bg-[rgba(254,246,231,0.28)] hover:border-[rgba(218,144,17,0.6)]'
+						: 'border-[#DDE2E5] hover:border-[#8485F6] hover:shadow-eachApp'
+				}`}
+			>
+				<div
+					className={`relative flex flex-col border-b px-[16px] py-[22px] ${
+						isSuspended ? 'border-[rgba(218,144,17,0.15)]' : 'border-[#F0F3F4]'
+					}`}
+				>
+					{logo ? (
+						<img
+							src={logo}
+							alt="#"
+							className={`max-h-[32px] min-h-[32px] w-fit object-contain ${
+								isSuspended ? 'opacity-60 grayscale' : ''
+							}`}
+						/>
+					) : (
+						<EachAppIcon
+							className={`mt-[6px] min-h-[32px] min-w-[32px] ${
+								isSuspended ? 'opacity-60' : ''
+							}`}
+						/>
+					)}
 
-				<div className="absolute bottom-[-10px] flex items-center gap-[8px]">
-					<div className="flex items-center gap-[4px] rounded-[16px] bg-[#F0F3F4] px-[8px] py-[4px]">
-						<EachAppRocketIcon className="min-h-[12px] min-w-[12px]" />
-						<span className="font-lato text-[9px] font-bold leading-[8px] tracking-[0.2px] text-[#495057]">
-							{formatLaunchDate(created_at)}
-						</span>
-					</div>
-					{isRecentlyLaunched(created_at) ? (
-						<div className="flex items-center gap-[4px] rounded-[16px] bg-[#E4F9F2] px-[8px] py-[6px]">
-							<span className="font-lato text-[9px] font-bold leading-[8px] tracking-[0.2px] text-[#186A50]">
-								Recently Launched
+					<div className="absolute bottom-[-10px] flex items-center gap-[8px]">
+						<div className="flex items-center gap-[4px] rounded-[16px] bg-[#F0F3F4] px-[8px] py-[4px]">
+							<EachAppRocketIcon className="min-h-[12px] min-w-[12px]" />
+							<span className="font-lato text-[9px] font-bold leading-[8px] tracking-[0.2px] text-[#495057]">
+								{formatLaunchDate(created_at)}
 							</span>
 						</div>
-					) : null}
+						{isSuspended ? (
+							<StatusPill status="suspended" />
+						) : isRecentlyLaunched(created_at) ? (
+							<div className="flex items-center gap-[4px] rounded-[16px] bg-[#E4F9F2] px-[8px] py-[6px]">
+								<span className="font-lato text-[9px] font-bold leading-[8px] tracking-[0.2px] text-[#186A50]">
+									Recently Launched
+								</span>
+							</div>
+						) : null}
+					</div>
 				</div>
-			</div>
-			<div data-cy="app_list" className="flex grow flex-col gap-[28px] px-[16px] pb-[16px] pt-[22px]">
-				<div className="flex grow flex-col gap-[8px]">
-					<span data-cy="app_id" className="font-lato text-[12px] font-bold uppercase leading-[20px] tracking-[0.6px] text-[#A3ABB1]">
-						App ID: {uuid?.slice(0, 7)}
-					</span>
-					<span data-cy="app_name" className="font-source-sans-pro text-[18px] font-semibold leading-[24px] tracking-[-0.2px] text-[#212429]">
-						{name}
-					</span>
-					<span data-cy="app_description "className="truncate font-lato text-[12px] leading-[16px] tracking-[0.2px] text-[#212429]">
-						{description}
-					</span>
-				</div>
-				<div data-cy="domain_url" className="flex flex-col gap-[8px]">
-					<span className="font-lato text-[12px] leading-[16px] tracking-[0.2px] text-[#000000]">
-						Modified {getTimeFromNow(modified_at)}
-					</span>
-					{last_released_version ? (
-						<span className="font-lato text-[13px] font-bold leading-[16px] tracking-[0.2px] text-[#8485F6]">
-							Latest Release {last_released_version}
+				<div
+					data-cy="app_list"
+					className="flex grow flex-col gap-[28px] px-[16px] pb-[16px] pt-[22px]"
+				>
+					<div className="flex grow flex-col gap-[8px]">
+						<span
+							data-cy="app_id"
+							className="font-lato text-[12px] font-bold uppercase leading-[20px] tracking-[0.6px] text-[#A3ABB1]"
+						>
+							App ID: {uuid?.slice(0, 7)}
 						</span>
-					) : null}
-					{domain_url ? <AppLinkButton domain_url={domain_url} /> : null}
+						<span
+							data-cy="app_name"
+							className={`font-source-sans-pro text-[18px] font-semibold leading-[24px] tracking-[-0.2px] ${
+								isSuspended ? 'text-[#5A607A]' : 'text-[#212429]'
+							}`}
+						>
+							{name}
+						</span>
+						<span
+							data-cy="app_description"
+							className="truncate font-lato text-[12px] leading-[16px] tracking-[0.2px] text-[#212429]"
+						>
+							{description}
+						</span>
+					</div>
+					<div data-cy="domain_url" className="flex flex-col gap-[8px]">
+						<span className="font-lato text-[12px] leading-[16px] tracking-[0.2px] text-[#000000]">
+							Modified {getTimeFromNow(modified_at)}
+						</span>
+						{last_released_version ? (
+							<span className="font-lato text-[13px] font-bold leading-[16px] tracking-[0.2px] text-[#8485F6]">
+								Latest Release {last_released_version}
+							</span>
+						) : null}
+						{domain_url ? <AppLinkButton domain_url={domain_url} /> : null}
+					</div>
 				</div>
-			</div>
-		</Link>
+			</Link>
+		</div>
 	);
 }

--- a/frontend/src/pages/platform/components/Platform/Apps/index.jsx
+++ b/frontend/src/pages/platform/components/Platform/Apps/index.jsx
@@ -8,6 +8,15 @@ import LaunchingApp from './LaunchingApp';
 export default function Apps() {
 	const appsData = useSelector(selectAppsData);
 
+	// Split by status so suspended apps live in their own labelled section
+	// at the bottom — visually distinct without being buried out of sight.
+	const active = [];
+	const suspended = [];
+	(appsData || []).forEach((app) => {
+		if (app?.status === 'suspended') suspended.push(app);
+		else active.push(app);
+	});
+
 	// `suspended` renders the same card as `deployed` — the card component
 	// reads `status` and applies its own suspended styling + kebab menu.
 	const renderApp = (eachApp) => {
@@ -30,13 +39,58 @@ export default function Apps() {
 					<LaunchNewAppButton />
 				</div>
 			</div>
-			<div className="flex min-h-0 grow flex-col gap-[16px]">
+			<div className="flex min-h-0 grow flex-col gap-[16px] overflow-y-auto pb-[29px]">
 				<div className="flex items-center justify-end gap-[8px] pr-[18px]">
 					<Filters />
 				</div>
-				<div data-cy= "app_list" className="complete-hidden-scroll-style grid grid-cols-1 items-stretch justify-start gap-[26px] overflow-y-auto pb-[29px] sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-5">
-					{appsData?.map(renderApp)}
+				<div
+					data-cy="app_list"
+					className="complete-hidden-scroll-style grid grid-cols-1 items-stretch justify-start gap-[26px] sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-5"
+				>
+					{active.map(renderApp)}
 				</div>
+
+				{suspended.length ? (
+					<div className="mt-[16px] flex flex-col gap-[16px]">
+						<div
+							className="flex items-center gap-[10px] pr-[18px]"
+							data-cy="suspended_apps_heading"
+						>
+							<span className="font-source-sans-pro text-[15px] font-semibold text-[#5A607A]">
+								Suspended
+							</span>
+							<span
+								className="inline-flex items-center gap-[6px] rounded-full border px-[8px] py-[2px] font-lato text-[10.5px] font-bold uppercase tracking-[0.06em]"
+								style={{
+									backgroundColor: '#FEF6E7',
+									borderColor: 'rgba(218,144,17,0.28)',
+									color: '#8A5A07',
+								}}
+							>
+								<span
+									aria-hidden
+									style={{
+										width: 6,
+										height: 6,
+										borderRadius: 999,
+										backgroundColor: '#DA9011',
+										boxShadow: '0 0 0 2px rgba(218,144,17,0.22)',
+									}}
+								/>
+								{suspended.length}
+							</span>
+							<span className="font-lato text-[12px] text-[#8389A3]">
+								blocked from serving traffic · data preserved
+							</span>
+						</div>
+						<div
+							data-cy="suspended_app_list"
+							className="complete-hidden-scroll-style grid grid-cols-1 items-stretch justify-start gap-[26px] sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-5"
+						>
+							{suspended.map(renderApp)}
+						</div>
+					</div>
+				) : null}
 			</div>
 		</div>
 	);

--- a/frontend/src/pages/platform/components/Platform/Apps/index.jsx
+++ b/frontend/src/pages/platform/components/Platform/Apps/index.jsx
@@ -8,6 +8,18 @@ import LaunchingApp from './LaunchingApp';
 export default function Apps() {
 	const appsData = useSelector(selectAppsData);
 
+	// `suspended` renders the same card as `deployed` — the card component
+	// reads `status` and applies its own suspended styling + kebab menu.
+	const renderApp = (eachApp) => {
+		if (eachApp?.status === 'staged') {
+			return <LaunchingApp key={eachApp?.uuid} data={eachApp} />;
+		}
+		if (eachApp?.status === 'deployed' || eachApp?.status === 'suspended') {
+			return <EachApp key={eachApp?.uuid} data={eachApp} />;
+		}
+		return null;
+	};
+
 	return (
 		<div className="flex h-full grow flex-col gap-[32px] px-[20px] pt-[29px] md:px-[46px]">
 			<div className="flex items-center justify-between pr-[18px]">
@@ -23,13 +35,7 @@ export default function Apps() {
 					<Filters />
 				</div>
 				<div data-cy= "app_list" className="complete-hidden-scroll-style grid grid-cols-1 items-stretch justify-start gap-[26px] overflow-y-auto pb-[29px] sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-4 2xl:grid-cols-5">
-					{appsData?.map(
-						(eachApp) =>
-							({
-								staged: <LaunchingApp key={eachApp?.uuid} data={eachApp} />,
-								deployed: <EachApp key={eachApp?.uuid} data={eachApp} />,
-							}[eachApp?.status])
-					)}
+					{appsData?.map(renderApp)}
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
Platform admins can now flip an app to \`suspended\` status. HTTP traffic returns a branded 404 page, background tasks routed through the two framework chokepoints raise \`TenantSuspended\` before touching workspace code, data is preserved, and unsuspend restores everything on the next request.

The full design + implementation walkthrough lives at \`backend/docs/app-suspension-plan.html\` — mockups, edge cases, and the reasoning behind each design decision. Below is the shipping summary.

## What's already in place — and what this PR adds

The \`TenantModel\` already carried \`status\` (with \`\"suspended\"\` as one of the values), \`suspended_on\` timestamp, and a \`suspend()\` method. **What was missing was enforcement.** Traffic flowed through regardless of status, tasks executed regardless of status, and there was no admin action to trigger the flip.

This PR adds:

- **Middleware enforcement** — short-circuits HTTP traffic to a branded 404 page
- **Framework-level Celery enforcement** — two chokepoints catch every tenant-scoped task
- **Admin API** — \`AppStatusActionView\` gated by \`IsSuperAdminPlatformUser\` for suspend/unsuspend
- **A symmetric \`unsuspend()\` method** on the model
- **A branded 404 template** — amber accents, lock icon, calm messaging

**No DB migration needed.** The status field already supports \`\"suspended\"\`.

## Backend changes

### 1. HTTP traffic — middleware guard

\`middleware/tenant.py\` — after \`connection.set_tenant\`, before URL routing:

\`\`\`python
if getattr(tenant, \"status\", None) == \"suspended\" and not self._is_suspend_exempt(request):
    return render(
        request,
        \"tenancy/app_suspended.html\",
        {\"tenant\": tenant, \"support_email\": settings.SUPPORT_EMAIL},
        status=404,
    )
\`\`\`

Two exemptions matter:

- \`/api/v1/health/\` — load balancers stay green
- \`/api/v1/platform/\` — operators can still unsuspend

Both are load-bearing. Without the platform exemption, the admin who just navigated to \`/platform/apps/\` to unsuspend the app would themselves get the 404.

### 2. Background work — framework chokepoints, no per-task decorators

Requiring every task author to remember a decorator is fragile. Instead, the assertion lives in the two framework wrappers every tenant-scoped Celery task naturally passes through:

**Chokepoint 1 · \`zango.core.tasks.zango_task_executor\`** — every workspace task (email/OTP/SMS/beat/chained/retried) routes through this. One assertion covers all of them.

\`\`\`python
tenant = TenantModel.objects.get(name=tenant_name)
connection.set_tenant(tenant)
assert_tenant_active(tenant)   # ← framework-level suspend guard
\`\`\`

**Chokepoint 2 · \`codexec_executor\`** — codexec has its own Celery task that doesn't route through \`zango_task_executor\`, so the same one-line assertion is added there too.

The two-chokepoint approach is deliberate — we considered a global \`task_prerun\` signal but it would fire for platform-level tasks (\`health_check\`, \`update_tool_usage_stats\`) that operate on the public schema and don't have a tenant. Explicit assertions at the two natural chokepoints are cheaper and cleaner.

### 3. Utility module

\`apps/shared/tenancy/utils.py\` — new \`TenantSuspended\` exception + \`assert_tenant_active(tenant)\` helper:

\`\`\`python
class TenantSuspended(Exception):
    \"\"\"Raised when a Celery task is invoked against a suspended tenant.\"\"\"


def assert_tenant_active(tenant=None):
    tenant = tenant or getattr(connection, \"tenant\", None)
    if tenant is not None and getattr(tenant, \"status\", None) == \"suspended\":
        logger.info(\"Task skipped: tenant '{}' is suspended\", tenant.schema_name)
        raise TenantSuspended(tenant.schema_name)
\`\`\`

Cheap — one attribute lookup, no DB roundtrip.

### 4. Symmetric \`unsuspend()\` method

\`\`\`python
def unsuspend(self):
    self.status = \"deployed\"
    self.suspended_on = None
    self.save()
\`\`\`

### 5. Admin API endpoint

\`POST /api/v1/platform/apps/<uuid>/status/<action>/\` where \`action\` is \`suspend\` or \`unsuspend\`. One view, gated by \`IsSuperAdminPlatformUser\`:

\`\`\`python
class AppStatusActionView(ZangoGenericPlatformAPIView):
    permission_classes = (IsSuperAdminPlatformUser,)
    _ALLOWED_ACTIONS = (\"suspend\", \"unsuspend\")

    def post(self, request, app_uuid, action):
        if action not in self._ALLOWED_ACTIONS:
            return get_api_response(False, {\"message\": f\"Unknown action '{action}'.\"}, 400)
        tenant = get_object_or_404(TenantModel, uuid=app_uuid)
        getattr(tenant, action)()      # tenant.suspend() or tenant.unsuspend()
        return get_api_response(True, {\"tenant\": TenantSerializerModel(tenant).data}, 200)
\`\`\`

### 6. The 404 template

\`apps/shared/tenancy/templates/tenancy/app_suspended.html\` — inline CSS only (no external static dependency). Amber accents (not red — this isn't a system error, it's an admin decision), Instrument Serif italic on \"suspended\", explicit \"your data is preserved\" line, mailto: support link.

## What we deliberately don't do

- **We don't purge the broker queue.** Tasks enqueued before suspension are caught on pickup by one of the two chokepoints and fail cleanly. Purging would require broker admin API calls per queue and would kill in-flight work.
- **We don't kill in-flight tasks.** \`revoke(terminate=True)\` mid-execution leaves DB rows in inconsistent states. A running codexec task finishes; the next dispatch is blocked.
- **We don't rely on per-task decorators.** The two chokepoints cover everything.

## What still needs to be built (out of scope for this PR)

- **Frontend** — status pill on the apps list, hover-reveal suspend action, type-to-confirm dialog. See section 07 of the plan doc for the design + code shape.

## Test plan

- [ ] Boot Django, verify \`assert_tenant_active\` raises for a stubbed suspended tenant and passes for a deployed one (already verified in local smoke — see commit message)
- [ ] Suspend a tenant via \`POST /api/v1/platform/apps/<uuid>/status/suspend/\` and visit the app's public URL → suspended page renders correctly with amber badge, icon, headline, and support mailto link
- [ ] Health check \`/api/v1/health/\` on the suspended app returns 200 (load balancer stays green)
- [ ] Platform admin API \`/api/v1/platform/apps/<uuid>/status/unsuspend/\` works on the suspended app (admin exemption)
- [ ] Trigger a workspace Celery task on a suspended tenant → task fails with \`TenantSuspended\` in the celery result, workspace code never loads
- [ ] Trigger a codexec run on a suspended tenant → \`TenantSuspended\` before AST recheck, before namespace setup
- [ ] Unsuspend and verify the next request succeeds normally
- [ ] Attempting an unknown action (e.g. \`/status/archive/\`) returns 400

## Files touched

- \`backend/src/zango/apps/shared/tenancy/utils.py\` (+32)
- \`backend/src/zango/apps/shared/tenancy/models.py\` (+11)
- \`backend/src/zango/middleware/tenant.py\` (+39)
- \`backend/src/zango/apps/shared/tenancy/templates/tenancy/app_suspended.html\` (new)
- \`backend/src/zango/core/tasks.py\` (+5)
- \`backend/src/zango/apps/code_execution/tasks.py\` (+8)
- \`backend/src/zango/api/platform/tenancy/v1/views.py\` (+41)
- \`backend/src/zango/api/platform/tenancy/v1/urls.py\` (+6)
- \`backend/docs/app-suspension-plan.html\` (design doc, new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)