### PR TITLE
prepare release 1.2.0b7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0b7] - 2026-07-22
+
+### Added
+
+* App suspension — block traffic + background tasks [(#605)](https://github.com/Healthlane-Technologies/Zango/pull/605)
+* App- and role-level session (idle) timeout configuration [(#607)](https://github.com/Healthlane-Technologies/Zango/pull/607)
+
 ## [1.2.0b6] - 2026-07-02
 
 ### Added

--- a/backend/setup.py
+++ b/backend/setup.py
@@ -7,7 +7,7 @@ PROJECT_DIR = os.path.dirname(__file__)
 REQUIREMENTS_DIR = os.path.join(PROJECT_DIR, "requirements")
 README = os.path.join(PROJECT_DIR, "README.md")
 
-PLATFORM_VERSION = "1.2.0b6"
+PLATFORM_VERSION = "1.2.0b7"
 
 
 def get_requirements(env):

--- a/backend/src/zango/__init__.py
+++ b/backend/src/zango/__init__.py
@@ -2,4 +2,4 @@ from zango.core import internal_requests
 
 
 __all__ = ["internal_requests"]
-__version__ = "1.2.0b6"
+__version__ = "1.2.0b7"


### PR DESCRIPTION
Version bump `1.2.0b6` → `1.2.0b7`.

## Changes
- \`backend/setup.py\` — \`PLATFORM_VERSION\` → 1.2.0b7
- \`backend/src/zango/__init__.py\` — \`__version__\` → 1.2.0b7
- \`CHANGELOG.md\` — new \`[1.2.0b7]\` section

### Added
* App suspension — block traffic + background tasks [(#605)](https://github.com/Healthlane-Technologies/Zango/pull/605)
* App- and role-level session (idle) timeout configuration [(#607)](https://github.com/Healthlane-Technologies/Zango/pull/607)

🤖 Generated with [Claude Code](https://claude.com/claude-code)